### PR TITLE
Corrected link hrefs and renamed bunch to bundlex

### DIFF
--- a/pages/creating-unifex-nif.md
+++ b/pages/creating-unifex-nif.md
@@ -4,7 +4,7 @@
 
 In order to start working on NIF we need prepare a few things:
 
-1. We need to add [Bunch](http://gihub.com/membraneframework/bunch) and [Unifex](http://gihub.com/membraneframework/unifex) to deps in `mix.exs`
+1. We need to add [Bundlex](https://github.com/membraneframework/bundlex) and [Unifex](https://github.com/membraneframework/unifex) to deps in `mix.exs`
     ```elixir
     defp deps do
         [


### PR DESCRIPTION
Links now lead to github not gihub. I assumed adding `Bunch` meant adding `Bundlex`