### PR TITLE
Allow native methods overrides

### DIFF
--- a/lib/unifex/loader.ex
+++ b/lib/unifex/loader.ex
@@ -46,10 +46,18 @@ defmodule Unifex.Loader do
         end
       end)
 
+    overrides =
+      fun_specs
+      |> Enum.map(fn {name, args, _results} ->
+        {name, length(args)}
+      end)
+
     quote do
       use Bundlex.Loader, nif: unquote(name)
 
       unquote_splicing(funs)
+
+      defoverridable unquote(overrides)
     end
   end
 end


### PR DESCRIPTION
## Description
Adds `defoverridable` for NIF methods.
This makes it possible to add default parameters for NIF methods calls, for example:
```elixir
use Unifex.Loader

def create(channels, sample_rate \\ 44_100) do
  super(channels, sample_rate)
end
```
which allows for calls like:
```elixir
Native.create(2)
```