### PR TITLE
Implement some lacking types for CNodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,17 @@ end
 
 ## Usage
 
-  For detailed usage description see [Creating Unifex Natives](https://hexdocs.pm/unifex/creating_unifex_natives.html) guide.
+For detailed usage description see [Creating Unifex Natives](https://hexdocs.pm/unifex/creating_unifex_natives.html) guide.
+
+## Supported types
+
+For currently supported types see [Supported Types](https://hexdocs.pm/unifex/supported_types.html) section.
 
 ## See also
 
-  Unifex depends on the following libraries:
-  - [Bundlex](https://github.com/membraneframework/bundlex)
-  - [Shmex](https://github.com/membraneframework/shmex)
+Unifex depends on the following libraries:
+- [Bundlex](https://github.com/membraneframework/bundlex)
+- [Shmex](https://github.com/membraneframework/shmex)
 
 ## Copyright and License
 

--- a/c_src/unifex/cnode/unifex/cnode.c
+++ b/c_src/unifex/cnode/unifex/cnode.c
@@ -53,19 +53,19 @@ void unifex_cnode_add_to_released_states(UnifexEnv *env, void *state) {
 }
 
 ei_x_buff unifex_cnode_string_to_list(UnifexCNodeInBuff *origin_buff, unsigned int strlen) {
-  char *p = malloc(sizeof(char) * strlen);
-  ei_decode_string(origin_buff->buff, origin_buff->index, p);
-  unsigned char *unsigned_p = (unsigned char *)p;
+  char *str = malloc(sizeof(char) * strlen);
+  ei_decode_string(origin_buff->buff, origin_buff->index, str);
+  unsigned char *unsigned_str = (unsigned char *)str;
 
   ei_x_buff buff;
   ei_x_new(&buff);
   ei_x_encode_list_header(&buff, strlen);
   for(unsigned int i = 0; i < strlen; i++) {
-    ei_x_encode_longlong(&buff, (unsigned long)unsigned_p[i]);
+    ei_x_encode_longlong(&buff, (long long)unsigned_str[i]);
   }
   ei_x_encode_empty_list(&buff);
 
-  free(p);
+  free(str);
   return buff;
 }
 

--- a/c_src/unifex/cnode/unifex/cnode.c
+++ b/c_src/unifex/cnode/unifex/cnode.c
@@ -52,6 +52,23 @@ void unifex_cnode_add_to_released_states(UnifexEnv *env, void *state) {
   env->released_states = list;
 }
 
+ei_x_buff unifex_cnode_string_to_list(UnifexCNodeInBuff *origin_buff, unsigned int strlen) {
+  char *p = malloc(sizeof(char) * strlen);
+  ei_decode_string(origin_buff->buff, origin_buff->index, p);
+  unsigned char *unsigned_p = (unsigned char *)p;
+
+  ei_x_buff buff;
+  ei_x_new(&buff);
+  ei_x_encode_list_header(&buff, strlen);
+  for(unsigned int i = 0; i < strlen; i++) {
+    ei_x_encode_longlong(&buff, (unsigned long)unsigned_p[i]);
+  }
+  ei_x_encode_empty_list(&buff);
+
+  free(p);
+  return buff;
+}
+
 static void free_released_states(UnifexEnv *env) {
   while (env->released_states) {
     void *state = env->released_states->head;

--- a/c_src/unifex/cnode/unifex/cnode.h
+++ b/c_src/unifex/cnode/unifex/cnode.h
@@ -28,6 +28,8 @@ void unifex_cnode_destroy_state(UnifexEnv *env, void *state);
 
 int unifex_cnode_init(int argc, char **argv, UnifexEnv *env);
 int unifex_cnode_receive(UnifexEnv *env);
+ei_x_buff unifex_cnode_string_to_list(UnifexCNodeInBuff *origin_buff,
+                                      unsigned int strlen);
 void unifex_cnode_destroy(UnifexEnv *env);
 
 #ifdef __cplusplus

--- a/c_src/unifex/cnode/unifex/unifex.h
+++ b/c_src/unifex/cnode/unifex/unifex.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 // required for ei.h to work
 #ifndef _REENTRANT

--- a/c_src/unifex/cnode/unifex/unifex.h
+++ b/c_src/unifex/cnode/unifex/unifex.h
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
 
 // required for ei.h to work
 #ifndef _REENTRANT

--- a/lib/unifex/code_generator/base_types/atom.ex
+++ b/lib/unifex/code_generator/base_types/atom.ex
@@ -3,6 +3,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.Atom do
   Module implementing `Unifex.CodeGenerator.BaseType` behaviour for atoms.
 
   Atoms in native code are represented by C-strings (`char *`)
+
+  Implemented both for NIF and CNode as function parameter as well as return type.
   """
   use Unifex.CodeGenerator.BaseType
   alias Unifex.CodeGenerator.BaseType

--- a/lib/unifex/code_generator/base_types/atom.ex
+++ b/lib/unifex/code_generator/base_types/atom.ex
@@ -42,8 +42,10 @@ defmodule Unifex.CodeGenerator.BaseTypes.Atom do
     @impl BaseType
     def generate_arg_parse(argument, name, _ctx) do
       ~g"""
+      ({
       #{name} = unifex_alloc(MAXATOMLEN);
-      ei_decode_atom(#{argument}->buff, #{argument}->index, #{name})
+      ei_decode_atom(#{argument}->buff, #{argument}->index, #{name});
+      })
       """
     end
   end

--- a/lib/unifex/code_generator/base_types/bool.ex
+++ b/lib/unifex/code_generator/base_types/bool.ex
@@ -3,6 +3,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.Bool do
   Module implementing `Unifex.CodeGenerator.BaseType` behaviour for boolean atoms.
 
   Booleans in native code are converted to int with value either 0 or 1.
+
+  Implemented only for NIF as function parameter as well as return type.
   """
   use Unifex.CodeGenerator.BaseType
   alias Unifex.CodeGenerator.BaseType

--- a/lib/unifex/code_generator/base_types/int.ex
+++ b/lib/unifex/code_generator/base_types/int.ex
@@ -24,7 +24,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.Int do
     def generate_arg_serialize(name, _ctx) do
       ~g"""
       ({
-      ei_x_encode_longlong(out_buff, (long long)#{name});
+      int tmp_int = #{name};
+      ei_x_encode_longlong(out_buff, (long long)tmp_int);
       });
       """
     end

--- a/lib/unifex/code_generator/base_types/int.ex
+++ b/lib/unifex/code_generator/base_types/int.ex
@@ -12,9 +12,9 @@ defmodule Unifex.CodeGenerator.BaseTypes.Int do
     def generate_arg_parse(argument, name, _ctx) do
       ~g"""
       ({
-        long long #{name}_longlong;
-        int result = ei_decode_longlong(#{argument}->buff, #{argument}->index, &#{name}_longlong);
-        #{name} = (int)#{name}_longlong;
+        long long tmp_longlong;
+        int result = ei_decode_longlong(#{argument}->buff, #{argument}->index, &tmp_longlong);
+        #{name} = (int)tmp_longlong;
         result;
       })
       """
@@ -24,8 +24,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.Int do
     def generate_arg_serialize(name, _ctx) do
       ~g"""
       ({
-      int #{name}_int = #{name};
-      ei_x_encode_longlong(out_buff, (long long)#{name}_int);
+      ei_x_encode_longlong(out_buff, (long long)#{name});
       });
       """
     end

--- a/lib/unifex/code_generator/base_types/int.ex
+++ b/lib/unifex/code_generator/base_types/int.ex
@@ -1,6 +1,8 @@
 defmodule Unifex.CodeGenerator.BaseTypes.Int do
   @moduledoc """
   Module implementing `Unifex.CodeGenerator.BaseType` behaviour for integers.
+
+  Implemented both for NIF and CNode as function parameter as well as return type.
   """
 
   defmodule CNode do

--- a/lib/unifex/code_generator/base_types/int64.ex
+++ b/lib/unifex/code_generator/base_types/int64.ex
@@ -3,6 +3,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.Int64 do
   Module implementing `Unifex.CodeGenerator.BaseType` behaviour for 64-bit integer.
 
   Maps `int64` Unifex type to an `int64_t` native type.
+
+  Implemented only for NIF as function parameter as well as return type.
   """
   alias Unifex.CodeGenerator.BaseType
   use BaseType

--- a/lib/unifex/code_generator/base_types/list.ex
+++ b/lib/unifex/code_generator/base_types/list.ex
@@ -4,6 +4,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
 
   They are represented in the native code as arrays with sizes passed
   via separate arguments.
+
+  Implemented both for NIF and CNode as function parameter as well as return type.
   """
   use Unifex.CodeGenerator.BaseType
   alias Unifex.CodeGenerator.BaseType

--- a/lib/unifex/code_generator/base_types/list.ex
+++ b/lib/unifex/code_generator/base_types/list.ex
@@ -129,27 +129,30 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
       ({
         int res = 1;
         int type;
-        char *p;
         ei_get_type(#{arg}->buff, #{arg}->index, &type, &#{len_var_name});
         if(type == ERL_LIST_EXT) {
           res = ei_decode_list_header(#{arg}->buff, #{arg}->index, &#{len_var_name});
-          #{var_name} = malloc(sizeof(#{BaseType.generate_native_type(ctx.subtype, ctx.generator)}) * #{len_var_name});
+          #{var_name} = malloc(sizeof(#{BaseType.generate_native_type(ctx.subtype, ctx.generator)}) * #{
+        len_var_name
+      });
 
           for(int i = 0; i < #{len_var_name}; i++) {
             #{BaseType.generate_initialization(ctx.subtype, elem_name, ctx.generator)}
           }
 
           for(int i = 0; i < #{len_var_name}; i++) {
-            #{BaseType.generate_arg_parse(
-              ctx.subtype,
-              elem_name,
-              arg,
-              ctx.postproc_fun,
-              ctx.generator
-            )}
+            #{
+        BaseType.generate_arg_parse(
+          ctx.subtype,
+          elem_name,
+          arg,
+          ctx.postproc_fun,
+          ctx.generator
+        )
+      }
           }
         } else if(type == ERL_STRING_EXT) {
-          p = malloc(sizeof(char)*#{len_var_name});
+          char *p = malloc(sizeof(char) * #{len_var_name});
           res = ei_decode_string(#{arg}->buff, #{arg}->index, p);
           #{var_name} = malloc(sizeof(int) * #{len_var_name});
           for(int i = 0; i < #{len_var_name}; i++) {

--- a/lib/unifex/code_generator/base_types/list.ex
+++ b/lib/unifex/code_generator/base_types/list.ex
@@ -116,7 +116,6 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
 
       ~g"""
       ({
-        int res = 1;
         int type;
         int size;
 
@@ -134,7 +133,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
           unifex_buff.buff = #{arg}->buff;
           unifex_buff.index = #{arg}->index;
         }
-        res = ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index, &size);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index, &size);
         #{len_var_name} = (unsigned int) size;
         #{var_name} = malloc(sizeof(#{native_type}) * #{len_var_name});
 
@@ -154,7 +153,6 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
       }
         }
         ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index, &size);
-        res;
       })
       """
     end

--- a/lib/unifex/code_generator/base_types/list.ex
+++ b/lib/unifex/code_generator/base_types/list.ex
@@ -131,6 +131,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
           unifex_buff->buff = buff.buff;
           *unifex_buff->index = 0;
         } else {
+          free(unifex_buff->index);
           unifex_buff->buff = #{arg}->buff;
           unifex_buff->index = #{arg}->index;
         }
@@ -148,7 +149,10 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
         BaseType.generate_arg_parse(subtype, elem_name, "unifex_buff", postproc_fun, generator)
       }
         }
-        res = ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        if(type == ERL_STRING_EXT) {
+          free(unifex_buff->index);
+        }
         free(unifex_buff);
         res;
       })

--- a/lib/unifex/code_generator/base_types/list.ex
+++ b/lib/unifex/code_generator/base_types/list.ex
@@ -5,11 +5,28 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
   They are represented in the native code as arrays with sizes passed
   via separate arguments.
   """
+  use Unifex.CodeGenerator.BaseType
+  alias Unifex.CodeGenerator.BaseType
+
+  @impl BaseType
+  def generate_initialization(name, _ctx) do
+    ~g<#{name} = NULL;>
+  end
 
   defmodule NIF do
     @moduledoc false
     use Unifex.CodeGenerator.BaseType
     alias Unifex.CodeGenerator.BaseType
+    @impl BaseType
+    def generate_native_type(ctx) do
+      prefix = if ctx.mode == :const, do: "const ", else: ""
+
+      [
+        "#{prefix}#{BaseType.generate_native_type(ctx.subtype, ctx.generator)}*",
+        {"unsigned int", "_length"}
+      ]
+    end
+
     @impl BaseType
     def generate_arg_serialize(name, ctx) do
       ~g"""
@@ -25,16 +42,6 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
         list;
       })
       """
-    end
-
-    @impl BaseType
-    def generate_native_type(ctx) do
-      prefix = if ctx.mode == :const, do: "const ", else: ""
-
-      [
-        "#{prefix}#{BaseType.generate_native_type(ctx.subtype, ctx.generator)}*",
-        {"unsigned int", "_length"}
-      ]
     end
 
     @impl BaseType
@@ -74,18 +81,101 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
     end
 
     @impl BaseType
-    def generate_initialization(name, _ctx) do
-      ~g<#{name} = NULL;>
-    end
-
-    @impl BaseType
     def generate_destruction(name, ctx) do
       ~g"""
       if(#{name} != NULL) {
         for(unsigned int i = 0; i < #{name}_length; i++) {
           #{BaseType.generate_destruction(ctx.subtype, :"#{name}[i]", ctx.generator)}
         }
-        enif_free(#{name});
+        unifex_free(#{name});
+      }
+      """
+    end
+  end
+
+  defmodule CNode do
+    @moduledoc false
+    use Unifex.CodeGenerator.BaseType
+    alias Unifex.CodeGenerator.BaseType
+    @impl BaseType
+    def generate_native_type(ctx) do
+      prefix = if ctx.mode == :const, do: "const ", else: ""
+
+      [
+        "#{prefix}#{BaseType.generate_native_type(ctx.subtype, ctx.generator)}*",
+        {"int", "_length"}
+      ]
+    end
+
+    @impl BaseType
+    def generate_arg_serialize(name, ctx) do
+      ~g"""
+      ({
+        ei_x_encode_list_header(out_buff, #{name}_length);
+        for(int i = 0; i < #{name}_length; i++) {
+          #{BaseType.generate_arg_serialize(ctx.subtype, :"#{name}[i]", ctx.generator)}
+        }
+        ei_x_encode_empty_list(out_buff);
+      });
+      """
+    end
+
+    @impl BaseType
+    def generate_arg_parse(arg, var_name, ctx) do
+      elem_name = :"#{var_name}[i]"
+      len_var_name = "#{var_name}_length"
+
+      ~g"""
+      ({
+        int res = 1;
+        int type;
+        char *p;
+        ei_get_type(#{arg}->buff, #{arg}->index, &type, &#{len_var_name});
+        if(type == ERL_LIST_EXT) {
+          res = ei_decode_list_header(#{arg}->buff, #{arg}->index, &#{len_var_name});
+          #{var_name} = malloc(sizeof(#{BaseType.generate_native_type(ctx.subtype, ctx.generator)}) * #{len_var_name});
+
+          for(int i = 0; i < #{len_var_name}; i++) {
+            #{BaseType.generate_initialization(ctx.subtype, elem_name, ctx.generator)}
+          }
+
+          for(int i = 0; i < #{len_var_name}; i++) {
+            #{BaseType.generate_arg_parse(
+              ctx.subtype,
+              elem_name,
+              arg,
+              ctx.postproc_fun,
+              ctx.generator
+            )}
+          }
+        } else if(type == ERL_STRING_EXT) {
+          p = malloc(sizeof(char)*#{len_var_name});
+          res = ei_decode_string(#{arg}->buff, #{arg}->index, p);
+          #{var_name} = malloc(sizeof(int) * #{len_var_name});
+          for(int i = 0; i < #{len_var_name}; i++) {
+            #ifdef __CHAR_UNSIGNED
+              #{elem_name} = (int)p[i];
+            #else
+              #{elem_name} = (int)p[i];
+              if(#{elem_name} < 0) {
+                #{elem_name} = #{elem_name} + 256;
+              }
+            #endif
+            }
+        }
+        res;
+      })
+      """
+    end
+
+    @impl BaseType
+    def generate_destruction(name, ctx) do
+      ~g"""
+      if(#{name} != NULL) {
+        for(int i = 0; i < #{name}_length; i++) {
+          #{BaseType.generate_destruction(ctx.subtype, :"#{name}[i]", ctx.generator)}
+        }
+        unifex_free(#{name});
       }
       """
     end

--- a/lib/unifex/code_generator/base_types/payload.ex
+++ b/lib/unifex/code_generator/base_types/payload.ex
@@ -1,6 +1,8 @@
 defmodule Unifex.CodeGenerator.BaseTypes.Payload do
   @moduledoc """
   Module implementing `Unifex.CodeGenerator.BaseType` behaviour for payloads.
+
+  Implemented both for NIF and CNode as function parameter as well as return type.
   """
   use Unifex.CodeGenerator.BaseType
   alias Unifex.CodeGenerator.BaseType

--- a/lib/unifex/code_generator/base_types/pid.ex
+++ b/lib/unifex/code_generator/base_types/pid.ex
@@ -25,4 +25,15 @@ defmodule Unifex.CodeGenerator.BaseTypes.Pid do
       ~g<enif_get_local_pid(env, #{arg}, &#{var_name})>
     end
   end
+
+  defmodule CNode do
+    @moduledoc false
+    use Unifex.CodeGenerator.BaseType
+    alias Unifex.CodeGenerator.BaseType
+
+    @impl BaseType
+    def generate_arg_serialize(name, ctx) do
+      ~g<ei_x_encode_pid(out_buff, &#{name});>
+    end
+  end
 end

--- a/lib/unifex/code_generator/base_types/pid.ex
+++ b/lib/unifex/code_generator/base_types/pid.ex
@@ -16,6 +16,11 @@ defmodule Unifex.CodeGenerator.BaseTypes.Pid do
     alias Unifex.CodeGenerator.BaseType
 
     @impl BaseType
+    def generate_arg_serialize(name, ctx) do
+      ~g<enif_make_pid(env, &#{name})>
+    end
+
+    @impl BaseType
     def generate_arg_parse(arg, var_name, _ctx) do
       ~g<enif_get_local_pid(env, #{arg}, &#{var_name})>
     end

--- a/lib/unifex/code_generator/base_types/pid.ex
+++ b/lib/unifex/code_generator/base_types/pid.ex
@@ -1,6 +1,8 @@
 defmodule Unifex.CodeGenerator.BaseTypes.Pid do
   @moduledoc """
   Module implementing `Unifex.CodeGenerator.BaseType` behaviour for Erlang PIDs.
+
+  Implemented both for NIF and CNode as function parameter as well as return type.
   """
   use Unifex.CodeGenerator.BaseType
   alias Unifex.CodeGenerator.BaseType
@@ -16,7 +18,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.Pid do
     alias Unifex.CodeGenerator.BaseType
 
     @impl BaseType
-    def generate_arg_serialize(name, ctx) do
+    def generate_arg_serialize(name, _ctx) do
       ~g<enif_make_pid(env, &#{name})>
     end
 
@@ -32,7 +34,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.Pid do
     alias Unifex.CodeGenerator.BaseType
 
     @impl BaseType
-    def generate_arg_serialize(name, ctx) do
+    def generate_arg_serialize(name, _ctx) do
       ~g<ei_x_encode_pid(out_buff, &#{name});>
     end
   end

--- a/lib/unifex/code_generator/base_types/string.ex
+++ b/lib/unifex/code_generator/base_types/string.ex
@@ -45,16 +45,6 @@ defmodule Unifex.CodeGenerator.BaseTypes.String do
     alias Unifex.CodeGenerator.BaseType
 
     @impl BaseType
-    def generate_arg_serialize(name, _ctx) do
-      ~g"""
-      ({
-        int str_len = strlen(#{name});
-        ei_x_encode_binary(out_buff, #{name}, str_len);
-      });
-      """
-    end
-
-    @impl BaseType
     def generate_arg_parse(arg, var_name, _ctx) do
       ~g"""
       ({
@@ -62,7 +52,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.String do
         int size;
         ei_get_type(#{arg}->buff, #{arg}->index, &type, &size);
         size = size + 1; // for NULL byte
-        ei_decode_binary(#{arg}->buff, #{arg}->index, #{var_name}, (long *)&size);
+        #{var_name} = malloc(sizeof(char) * size);
+        ei_decode_string(#{arg}->buff, #{arg}->index, #{var_name});
       })
       """
     end

--- a/lib/unifex/code_generator/base_types/string.ex
+++ b/lib/unifex/code_generator/base_types/string.ex
@@ -38,4 +38,20 @@ defmodule Unifex.CodeGenerator.BaseTypes.String do
       ~g<unifex_free(#{name});>
     end
   end
+
+  defmodule CNode do
+    @moduledoc false
+    use Unifex.CodeGenerator.BaseType
+    alias Unifex.CodeGenerator.BaseType
+
+    @impl BaseType
+    def generate_initialization(name, _ctx) do
+      ~g<#{name} = (char *)malloc(255*sizeof(char));>
+    end
+
+    @impl BaseType
+    def generate_arg_parse(arg, var_name, _ctx) do
+      ~g<ei_decode_string(#{arg}-\>buff, #{arg}-\>index, #{var_name})>
+    end
+  end
 end

--- a/lib/unifex/code_generator/base_types/string.ex
+++ b/lib/unifex/code_generator/base_types/string.ex
@@ -3,6 +3,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.String do
   Module implementing `Unifex.CodeGenerator.BaseType` behaviour for strings.
 
   They are represented by NULL-terminated char arrays.
+
+  Implemented both for NIF and CNode as function parameter as well as return type.
   """
   use Unifex.CodeGenerator.BaseType
   alias Unifex.CodeGenerator.BaseType

--- a/lib/unifex/code_generator/base_types/uint64.ex
+++ b/lib/unifex/code_generator/base_types/uint64.ex
@@ -3,6 +3,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.Uint64 do
   Module implementing `Unifex.CodeGenerator.BaseType` behaviour for 64-bit unsigned integer.
 
   Maps `uint64` Unifex type to a `uint64_t` native type.
+
+  Implemented only for NIF as function parameter as well as return type.
   """
   use Unifex.CodeGenerator.BaseType
   alias Unifex.CodeGenerator.BaseType

--- a/lib/unifex/code_generator/base_types/unsigned.ex
+++ b/lib/unifex/code_generator/base_types/unsigned.ex
@@ -1,6 +1,8 @@
 defmodule Unifex.CodeGenerator.BaseTypes.Unsigned do
   @moduledoc """
   Module implementing `Unifex.CodeGenerator.BaseType` behaviour for unsigned int.
+
+  Implemented both for NIF and CNode as function parameter as well as return type.
   """
   use Unifex.CodeGenerator.BaseType
   alias Unifex.CodeGenerator.BaseType

--- a/lib/unifex/code_generator/base_types/unsigned.ex
+++ b/lib/unifex/code_generator/base_types/unsigned.ex
@@ -35,8 +35,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.Unsigned do
     def generate_arg_serialize(name, _ctx) do
       ~g"""
       ({
-        unsigned int #{name}_uint = #{name};
-        ei_x_encode_ulonglong(out_buff, (unsigned long long)#{name}_uint);
+        unsigned int tmp_uint = #{name};
+        ei_x_encode_ulonglong(out_buff, (unsigned long long)tmp_uint);
       });
       """
     end
@@ -45,9 +45,9 @@ defmodule Unifex.CodeGenerator.BaseTypes.Unsigned do
     def generate_arg_parse(argument, name, _ctx) do
       ~g"""
       ({
-        unsigned long long #{name}_ulonglong;
-        int result = ei_decode_ulonglong(#{argument}->buff, #{argument}->index, &#{name}_ulonglong);
-        #{name} = (unsigned int)#{name}_ulonglong;
+        unsigned long long tmp_ulonglong;
+        int result = ei_decode_ulonglong(#{argument}->buff, #{argument}->index, &tmp_ulonglong);
+        #{name} = (unsigned int)tmp_ulonglong;
         result;
       })
       """

--- a/lib/unifex/code_generator/base_types/unsigned.ex
+++ b/lib/unifex/code_generator/base_types/unsigned.ex
@@ -25,4 +25,32 @@ defmodule Unifex.CodeGenerator.BaseTypes.Unsigned do
       ~g<enif_get_uint(env, #{arg_term}, &#{var_name})>
     end
   end
+
+  defmodule CNode do
+    @moduledoc false
+    use Unifex.CodeGenerator.BaseType
+    alias Unifex.CodeGenerator.BaseType
+
+    @impl BaseType
+    def generate_arg_serialize(name, _ctx) do
+      ~g"""
+      ({
+        unsigned int #{name}_uint = #{name};
+        ei_x_encode_ulonglong(out_buff, (unsigned long long)#{name}_uint);
+      });
+      """
+    end
+
+    @impl BaseType
+    def generate_arg_parse(argument, name, _ctx) do
+      ~g"""
+      ({
+        unsigned long long #{name}_ulonglong;
+        int result = ei_decode_ulonglong(#{argument}->buff, #{argument}->index, &#{name}_ulonglong);
+        #{name} = (unsigned int)#{name}_ulonglong;
+        result;
+      })
+      """
+    end
+  end
 end

--- a/lib/unifex/code_generators/cnode.ex
+++ b/lib/unifex/code_generators/cnode.ex
@@ -243,7 +243,7 @@ defmodule Unifex.CodeGenerators.CNode do
     implemented_fun_args =
       [
         "env"
-        | Enum.map(args, fn {name, type} -> BaseType.generate_arg_name(type, name, CNode) end)
+        | Enum.flat_map(args, fn {name, type} -> BaseType.generate_arg_name(type, name, CNode) end)
       ]
       |> Enum.join(", ")
 

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Unifex.MixProject do
   defp docs do
     [
       main: "readme",
-      extras: ["README.md", "pages/creating_unifex_natives.md"],
+      extras: ["README.md", "pages/creating_unifex_natives.md", "pages/supported_types.md"],
       source_ref: "v#{@version}",
       nest_modules_by_prefix: [
         Unifex.CodeGenerators,

--- a/pages/supported_types.md
+++ b/pages/supported_types.md
@@ -1,0 +1,35 @@
+# Supported types
+
+Unifenosupports generating code both for usage with NIF's and CNode's. 
+Nevertheless, some types can be not implemented yet.
+Below we present which types you can use at this moment. 
+You can also refer to [#42](https://github.com/membraneframework/unifenoissues/42) to see 
+state of work on remaining types.
+
+## NIF
+| type    | as function parameter | as return type  |
+| ------- | :-------------------: | :-------------: |
+| atom    | yes                   | yes             |
+| bool    | yes                   | yes             |
+| uint    | yes                   | yes             |
+| uint64  | yes                   | yes             |
+| int     | yes                   | yes             |
+| int64   | yes                   | yes             |
+| list    | yes                   | yes             |
+| payload | yes                   | yes             |
+| pid     | yes                   | yes             |
+| string  | yes                   | yes             |
+
+## CNode
+| type    | as function parameter | as return type  |
+| ------- | :-------------------: | :-------------: |
+| atom    | yes                   | yes             |
+| bool    | no                    | no              |
+| uint    | yes                   | yes             |
+| uint64  | no                    | no              |
+| int     | yes                   | yes             |
+| int64   | no                    | no              |
+| list    | yes                   | yes             |
+| payload | yes                   | yes             |
+| pid     | yes                   | yes             |
+| string  | yes                   | yes             |

--- a/pages/supported_types.md
+++ b/pages/supported_types.md
@@ -1,9 +1,9 @@
 # Supported types
 
-Unifenosupports generating code both for usage with NIF's and CNode's. 
+Unifex supports generating code both for usage with NIF's and CNode's. 
 Nevertheless, some types can be not implemented yet.
 Below we present which types you can use at this moment. 
-You can also refer to [#42](https://github.com/membraneframework/unifenoissues/42) to see 
+You can also refer to [#42](https://github.com/membraneframework/unifex/issues/42) to see 
 state of work on remaining types.
 
 ## NIF

--- a/test/fixtures/bundlex_exs_ref_generated/cnode/example.c
+++ b/test/fixtures/bundlex_exs_ref_generated/cnode/example.c
@@ -10,8 +10,8 @@ UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
   ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "ok");
   ({
-    int answer_int = answer;
-    ei_x_encode_longlong(out_buff, (long long)answer_int);
+    int tmp_int = answer;
+    ei_x_encode_longlong(out_buff, (long long)tmp_int);
   });
 
   return out_buff;
@@ -23,10 +23,10 @@ UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   int num;
 
   if (({
-        long long num_longlong;
+        long long tmp_longlong;
         int result =
-            ei_decode_longlong(in_buff->buff, in_buff->index, &num_longlong);
-        num = (int)num_longlong;
+            ei_decode_longlong(in_buff->buff, in_buff->index, &tmp_longlong);
+        num = (int)tmp_longlong;
         result;
       })) {
     result = unifex_raise(

--- a/test/fixtures/bundlex_exs_ref_generated/cnode/example.cpp
+++ b/test/fixtures/bundlex_exs_ref_generated/cnode/example.cpp
@@ -10,8 +10,8 @@ UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
   ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "ok");
   ({
-    int answer_int = answer;
-    ei_x_encode_longlong(out_buff, (long long)answer_int);
+    int tmp_int = answer;
+    ei_x_encode_longlong(out_buff, (long long)tmp_int);
   });
 
   return out_buff;
@@ -23,10 +23,10 @@ UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   int num;
 
   if (({
-        long long num_longlong;
+        long long tmp_longlong;
         int result =
-            ei_decode_longlong(in_buff->buff, in_buff->index, &num_longlong);
-        num = (int)num_longlong;
+            ei_decode_longlong(in_buff->buff, in_buff->index, &tmp_longlong);
+        num = (int)tmp_longlong;
         result;
       })) {
     result = unifex_raise(

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -293,27 +293,14 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_list_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff;
-        unifex_buff = malloc(sizeof(UnifexCNodeInBuff));
+        UnifexCNodeInBuff *unifex_buff =
+            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
+        unifex_buff->index = (int *)malloc(sizeof(int));
+
         if (type == ERL_STRING_EXT) {
-          char *p = malloc(sizeof(char) * in_list_length);
-          res = ei_decode_string(in_buff->buff, in_buff->index, p);
-          unsigned char *unsigned_p = (unsigned char *)p;
-
-          ei_x_buff buff;
-          ei_x_new_with_version(&buff);
-          ei_x_encode_list_header(&buff, in_list_length);
-          for (unsigned int i = 0; i < in_list_length; i++) {
-            ei_x_encode_ulong(&buff, (unsigned long)unsigned_p[i]);
-          }
-          ei_x_encode_empty_list(&buff);
-
-          int version;
-          int index = 0;
-          ei_decode_version(buff.buff, &index, &version);
-          res = ei_get_type(buff.buff, &index, &type, &size);
+          ei_x_buff buff = unifex_cnode_string_to_list(in_buff, in_list_length);
           unifex_buff->buff = buff.buff;
-          unifex_buff->index = &index;
+          *unifex_buff->index = 0;
         } else {
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
@@ -340,7 +327,9 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
             goto exit_test_list_caller;
           }
         }
-        res = ei_skip_term(unifex_buff->buff, unifex_buff->index);
+        res =
+            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        free(unifex_buff);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "
@@ -375,27 +364,15 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_strings_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff;
-        unifex_buff = malloc(sizeof(UnifexCNodeInBuff));
+        UnifexCNodeInBuff *unifex_buff =
+            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
+        unifex_buff->index = (int *)malloc(sizeof(int));
+
         if (type == ERL_STRING_EXT) {
-          char *p = malloc(sizeof(char) * in_strings_length);
-          res = ei_decode_string(in_buff->buff, in_buff->index, p);
-          unsigned char *unsigned_p = (unsigned char *)p;
-
-          ei_x_buff buff;
-          ei_x_new_with_version(&buff);
-          ei_x_encode_list_header(&buff, in_strings_length);
-          for (unsigned int i = 0; i < in_strings_length; i++) {
-            ei_x_encode_ulong(&buff, (unsigned long)unsigned_p[i]);
-          }
-          ei_x_encode_empty_list(&buff);
-
-          int version;
-          int index = 0;
-          ei_decode_version(buff.buff, &index, &version);
-          res = ei_get_type(buff.buff, &index, &type, &size);
+          ei_x_buff buff =
+              unifex_cnode_string_to_list(in_buff, in_strings_length);
           unifex_buff->buff = buff.buff;
-          unifex_buff->index = &index;
+          *unifex_buff->index = 0;
         } else {
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
@@ -427,7 +404,9 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
             goto exit_test_list_of_strings_caller;
           }
         }
-        res = ei_skip_term(unifex_buff->buff, unifex_buff->index);
+        res =
+            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        free(unifex_buff);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument "
@@ -463,27 +442,15 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_uints_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff;
-        unifex_buff = malloc(sizeof(UnifexCNodeInBuff));
+        UnifexCNodeInBuff *unifex_buff =
+            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
+        unifex_buff->index = (int *)malloc(sizeof(int));
+
         if (type == ERL_STRING_EXT) {
-          char *p = malloc(sizeof(char) * in_uints_length);
-          res = ei_decode_string(in_buff->buff, in_buff->index, p);
-          unsigned char *unsigned_p = (unsigned char *)p;
-
-          ei_x_buff buff;
-          ei_x_new_with_version(&buff);
-          ei_x_encode_list_header(&buff, in_uints_length);
-          for (unsigned int i = 0; i < in_uints_length; i++) {
-            ei_x_encode_ulong(&buff, (unsigned long)unsigned_p[i]);
-          }
-          ei_x_encode_empty_list(&buff);
-
-          int version;
-          int index = 0;
-          ei_decode_version(buff.buff, &index, &version);
-          res = ei_get_type(buff.buff, &index, &type, &size);
+          ei_x_buff buff =
+              unifex_cnode_string_to_list(in_buff, in_uints_length);
           unifex_buff->buff = buff.buff;
-          unifex_buff->index = &index;
+          *unifex_buff->index = 0;
         } else {
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
@@ -511,7 +478,9 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
             goto exit_test_list_of_uints_caller;
           }
         }
-        res = ei_skip_term(unifex_buff->buff, unifex_buff->index);
+        res =
+            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        free(unifex_buff);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_uints' "
@@ -548,27 +517,14 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_list_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff;
-        unifex_buff = malloc(sizeof(UnifexCNodeInBuff));
+        UnifexCNodeInBuff *unifex_buff =
+            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
+        unifex_buff->index = (int *)malloc(sizeof(int));
+
         if (type == ERL_STRING_EXT) {
-          char *p = malloc(sizeof(char) * in_list_length);
-          res = ei_decode_string(in_buff->buff, in_buff->index, p);
-          unsigned char *unsigned_p = (unsigned char *)p;
-
-          ei_x_buff buff;
-          ei_x_new_with_version(&buff);
-          ei_x_encode_list_header(&buff, in_list_length);
-          for (unsigned int i = 0; i < in_list_length; i++) {
-            ei_x_encode_ulong(&buff, (unsigned long)unsigned_p[i]);
-          }
-          ei_x_encode_empty_list(&buff);
-
-          int version;
-          int index = 0;
-          ei_decode_version(buff.buff, &index, &version);
-          res = ei_get_type(buff.buff, &index, &type, &size);
+          ei_x_buff buff = unifex_cnode_string_to_list(in_buff, in_list_length);
           unifex_buff->buff = buff.buff;
-          unifex_buff->index = &index;
+          *unifex_buff->index = 0;
         } else {
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
@@ -595,7 +551,9 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
             goto exit_test_list_with_other_args_caller;
           }
         }
-        res = ei_skip_term(unifex_buff->buff, unifex_buff->index);
+        res =
+            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        free(unifex_buff);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -293,22 +293,19 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_list_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff =
-            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
-        unifex_buff->index = (int *)malloc(sizeof(int));
-
+        int index = 0;
+        UnifexCNodeInBuff unifex_buff;
+        UnifexCNodeInBuff *unifex_buff_ptr = &unifex_buff;
         if (type == ERL_STRING_EXT) {
           ei_x_buff buff = unifex_cnode_string_to_list(in_buff, in_list_length);
-          unifex_buff->buff = buff.buff;
-          *unifex_buff->index = 0;
+          unifex_buff.buff = buff.buff;
+          unifex_buff.index = &index;
         } else {
-          free(unifex_buff->index);
-          unifex_buff->buff = in_buff->buff;
-          unifex_buff->index = in_buff->index;
+          unifex_buff.buff = in_buff->buff;
+          unifex_buff.index = in_buff->index;
         }
-
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        res = ei_decode_list_header(unifex_buff_ptr->buff,
+                                    unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
         in_list = malloc(sizeof(int) * in_list_length);
 
@@ -318,8 +315,9 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         for (unsigned int i = 0; i < in_list_length; i++) {
           if (({
                 long long tmp_longlong;
-                int result = ei_decode_longlong(
-                    unifex_buff->buff, unifex_buff->index, &tmp_longlong);
+                int result =
+                    ei_decode_longlong(unifex_buff_ptr->buff,
+                                       unifex_buff_ptr->index, &tmp_longlong);
                 in_list[i] = (int)tmp_longlong;
                 result;
               })) {
@@ -328,11 +326,8 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
             goto exit_test_list_caller;
           }
         }
-        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
-        if (type == ERL_STRING_EXT) {
-          free(unifex_buff->index);
-        }
-        free(unifex_buff);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "
@@ -367,23 +362,20 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_strings_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff =
-            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
-        unifex_buff->index = (int *)malloc(sizeof(int));
-
+        int index = 0;
+        UnifexCNodeInBuff unifex_buff;
+        UnifexCNodeInBuff *unifex_buff_ptr = &unifex_buff;
         if (type == ERL_STRING_EXT) {
           ei_x_buff buff =
               unifex_cnode_string_to_list(in_buff, in_strings_length);
-          unifex_buff->buff = buff.buff;
-          *unifex_buff->index = 0;
+          unifex_buff.buff = buff.buff;
+          unifex_buff.index = &index;
         } else {
-          free(unifex_buff->index);
-          unifex_buff->buff = in_buff->buff;
-          unifex_buff->index = in_buff->index;
+          unifex_buff.buff = in_buff->buff;
+          unifex_buff.index = in_buff->index;
         }
-
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        res = ei_decode_list_header(unifex_buff_ptr->buff,
+                                    unifex_buff_ptr->index, &size);
         in_strings_length = (unsigned int)size;
         in_strings = malloc(sizeof(char *) * in_strings_length);
 
@@ -395,11 +387,11 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
           if (({
                 int type;
                 int size;
-                ei_get_type(unifex_buff->buff, unifex_buff->index, &type,
-                            &size);
+                ei_get_type(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                            &type, &size);
                 size = size + 1; // for NULL byte
                 in_strings[i] = malloc(sizeof(char) * size);
-                ei_decode_string(unifex_buff->buff, unifex_buff->index,
+                ei_decode_string(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                                  in_strings[i]);
               })) {
             result =
@@ -408,11 +400,8 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
             goto exit_test_list_of_strings_caller;
           }
         }
-        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
-        if (type == ERL_STRING_EXT) {
-          free(unifex_buff->index);
-        }
-        free(unifex_buff);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument "
@@ -448,23 +437,20 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_uints_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff =
-            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
-        unifex_buff->index = (int *)malloc(sizeof(int));
-
+        int index = 0;
+        UnifexCNodeInBuff unifex_buff;
+        UnifexCNodeInBuff *unifex_buff_ptr = &unifex_buff;
         if (type == ERL_STRING_EXT) {
           ei_x_buff buff =
               unifex_cnode_string_to_list(in_buff, in_uints_length);
-          unifex_buff->buff = buff.buff;
-          *unifex_buff->index = 0;
+          unifex_buff.buff = buff.buff;
+          unifex_buff.index = &index;
         } else {
-          free(unifex_buff->index);
-          unifex_buff->buff = in_buff->buff;
-          unifex_buff->index = in_buff->index;
+          unifex_buff.buff = in_buff->buff;
+          unifex_buff.index = in_buff->index;
         }
-
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        res = ei_decode_list_header(unifex_buff_ptr->buff,
+                                    unifex_buff_ptr->index, &size);
         in_uints_length = (unsigned int)size;
         in_uints = malloc(sizeof(unsigned int) * in_uints_length);
 
@@ -474,8 +460,9 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         for (unsigned int i = 0; i < in_uints_length; i++) {
           if (({
                 unsigned long long tmp_ulonglong;
-                int result = ei_decode_ulonglong(
-                    unifex_buff->buff, unifex_buff->index, &tmp_ulonglong);
+                int result =
+                    ei_decode_ulonglong(unifex_buff_ptr->buff,
+                                        unifex_buff_ptr->index, &tmp_ulonglong);
                 in_uints[i] = (unsigned int)tmp_ulonglong;
                 result;
               })) {
@@ -485,11 +472,8 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
             goto exit_test_list_of_uints_caller;
           }
         }
-        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
-        if (type == ERL_STRING_EXT) {
-          free(unifex_buff->index);
-        }
-        free(unifex_buff);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_uints' "
@@ -526,22 +510,19 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_list_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff =
-            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
-        unifex_buff->index = (int *)malloc(sizeof(int));
-
+        int index = 0;
+        UnifexCNodeInBuff unifex_buff;
+        UnifexCNodeInBuff *unifex_buff_ptr = &unifex_buff;
         if (type == ERL_STRING_EXT) {
           ei_x_buff buff = unifex_cnode_string_to_list(in_buff, in_list_length);
-          unifex_buff->buff = buff.buff;
-          *unifex_buff->index = 0;
+          unifex_buff.buff = buff.buff;
+          unifex_buff.index = &index;
         } else {
-          free(unifex_buff->index);
-          unifex_buff->buff = in_buff->buff;
-          unifex_buff->index = in_buff->index;
+          unifex_buff.buff = in_buff->buff;
+          unifex_buff.index = in_buff->index;
         }
-
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        res = ei_decode_list_header(unifex_buff_ptr->buff,
+                                    unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
         in_list = malloc(sizeof(int) * in_list_length);
 
@@ -551,8 +532,9 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         for (unsigned int i = 0; i < in_list_length; i++) {
           if (({
                 long long tmp_longlong;
-                int result = ei_decode_longlong(
-                    unifex_buff->buff, unifex_buff->index, &tmp_longlong);
+                int result =
+                    ei_decode_longlong(unifex_buff_ptr->buff,
+                                       unifex_buff_ptr->index, &tmp_longlong);
                 in_list[i] = (int)tmp_longlong;
                 result;
               })) {
@@ -561,11 +543,8 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
             goto exit_test_list_with_other_args_caller;
           }
         }
-        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
-        if (type == ERL_STRING_EXT) {
-          free(unifex_buff->index);
-        }
-        free(unifex_buff);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -28,24 +28,101 @@ UNIFEX_TERM init_result_ok(UnifexEnv *env, UnifexState *state) {
   return out_buff;
 }
 
-UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer,
-                          UnifexPayload *out_payload) {
+UNIFEX_TERM test_uint_result_ok(UnifexEnv *env, unsigned int out_uint) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
 
-  ei_x_encode_tuple_header(out_buff, 3);
+  ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "ok");
   ({
-    int answer_int = answer;
-    ei_x_encode_longlong(out_buff, (long long)answer_int);
+    unsigned int out_uint_uint = out_uint;
+    ei_x_encode_ulonglong(out_buff, (unsigned long long)out_uint_uint);
   });
 
+  return out_buff;
+}
+
+UNIFEX_TERM test_string_result_ok(UnifexEnv *env, const char *out_string) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 2);
+  ei_x_encode_atom(out_buff, "ok");
+  ei_x_encode_string(out_buff, out_string);
+
+  return out_buff;
+}
+
+UNIFEX_TERM test_list_result_ok(UnifexEnv *env, const int *out_list,
+                                int out_list_length) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 2);
+  ei_x_encode_atom(out_buff, "ok");
+  ({
+    ei_x_encode_list_header(out_buff, out_list_length);
+    for (int i = 0; i < out_list_length; i++) {
+      ({ ei_x_encode_longlong(out_buff, (long long)out_list[i]); });
+    }
+    ei_x_encode_empty_list(out_buff);
+  });
+
+  return out_buff;
+}
+
+UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env,
+                                           const char **out_strings,
+                                           int out_strings_length) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 2);
+  ei_x_encode_atom(out_buff, "ok");
+  ({
+    ei_x_encode_list_header(out_buff, out_strings_length);
+    for (int i = 0; i < out_strings_length; i++) {
+      ei_x_encode_string(out_buff, out_strings[i]);
+    }
+    ei_x_encode_empty_list(out_buff);
+  });
+
+  return out_buff;
+}
+
+UNIFEX_TERM test_payload_result_ok(UnifexEnv *env, UnifexPayload *out_payload) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 2);
+  ei_x_encode_atom(out_buff, "ok");
   unifex_payload_encode(env, out_buff, out_payload);
 
   return out_buff;
 }
 
-UNIFEX_TERM foo_result_error(UnifexEnv *env, const char *reason) {
+UNIFEX_TERM test_pid_result_ok(UnifexEnv *env) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 1);
+  ei_x_encode_atom(out_buff, "ok");
+
+  return out_buff;
+}
+
+UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 1);
+  ei_x_encode_atom(out_buff, "ok");
+
+  return out_buff;
+}
+
+UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
+                                              const char *reason) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
 
@@ -67,43 +144,241 @@ exit_init_caller:
   return result;
 }
 
-UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+UNIFEX_TERM test_uint_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   UNIFEX_TERM result;
 
-  UnifexPid target;
-  UnifexPayload *in_payload;
-  UnifexState *state;
+  unsigned int in_uint;
 
-  in_payload = NULL;
-
-  if (ei_decode_pid(in_buff->buff, in_buff->index, &target)) {
+  if (({
+        unsigned long long in_uint_ulonglong;
+        int result = ei_decode_ulonglong(in_buff->buff, in_buff->index,
+                                         &in_uint_ulonglong);
+        in_uint = (unsigned int)in_uint_ulonglong;
+        result;
+      })) {
     result = unifex_raise(
-        env, "Unifex CNode: cannot parse argument 'target' of type ':pid'");
-    goto exit_foo_caller;
+        env,
+        "Unifex CNode: cannot parse argument 'in_uint' of type ':unsigned'");
+    goto exit_test_uint_caller;
   }
 
+  result = test_uint(env, in_uint);
+  goto exit_test_uint_caller;
+exit_test_uint_caller:
+
+  return result;
+}
+
+UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  char *in_string;
+  in_string = NULL;
+  if (({
+        int type;
+        int size;
+        ei_get_type(in_buff->buff, in_buff->index, &type, &size);
+        size = size + 1; // for NULL byte
+        in_string = malloc(sizeof(char) * size);
+        ei_decode_string(in_buff->buff, in_buff->index, in_string);
+      })) {
+    result = unifex_raise(
+        env,
+        "Unifex CNode: cannot parse argument 'in_string' of type ':string'");
+    goto exit_test_string_caller;
+  }
+
+  result = test_string(env, in_string);
+  goto exit_test_string_caller;
+exit_test_string_caller:
+  unifex_free(in_string);
+  return result;
+}
+
+UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  int *in_list;
+  int in_list_length;
+  in_list = NULL;
+  if (({
+        int res = 1;
+        int type;
+        ei_get_type(in_buff->buff, in_buff->index, &type, &in_list_length);
+        if (type == ERL_LIST_EXT) {
+          res = ei_decode_list_header(in_buff->buff, in_buff->index,
+                                      &in_list_length);
+          in_list = malloc(sizeof(int) * in_list_length);
+
+          for (int i = 0; i < in_list_length; i++) {
+          }
+
+          for (int i = 0; i < in_list_length; i++) {
+            if (({
+                  long long tmp_longlong;
+                  int result = ei_decode_longlong(in_buff->buff, in_buff->index,
+                                                  &tmp_longlong);
+                  in_list[i] = (int)tmp_longlong;
+                  result;
+                })) {
+              result = unifex_raise(env, "Unifex CNode: cannot parse argument "
+                                         "'in_list' of type '{:list, :int}'");
+              goto exit_test_list_caller;
+            }
+          }
+        } else if (type == ERL_STRING_EXT) {
+          char *p = malloc(sizeof(char) * in_list_length);
+          res = ei_decode_string(in_buff->buff, in_buff->index, p);
+          in_list = malloc(sizeof(int) * in_list_length);
+          for (int i = 0; i < in_list_length; i++) {
+#ifdef __CHAR_UNSIGNED
+            in_list[i] = (int)p[i];
+#else
+            in_list[i] = (int)p[i];
+            if (in_list[i] < 0) {
+              in_list[i] = in_list[i] + 256;
+            }
+#endif
+          }
+        }
+        res;
+      })) {
+    result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "
+                               "of type '{:list, :int}'");
+    goto exit_test_list_caller;
+  }
+
+  result = test_list(env, in_list, in_list_length);
+  goto exit_test_list_caller;
+exit_test_list_caller:
+  if (in_list != NULL) {
+    for (int i = 0; i < in_list_length; i++) {
+    }
+    unifex_free(in_list);
+  }
+
+  return result;
+}
+
+UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
+                                        UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  char **in_strings;
+  int in_strings_length;
+  in_strings = NULL;
+  if (({
+        int res = 1;
+        int type;
+        ei_get_type(in_buff->buff, in_buff->index, &type, &in_strings_length);
+        if (type == ERL_LIST_EXT) {
+          res = ei_decode_list_header(in_buff->buff, in_buff->index,
+                                      &in_strings_length);
+          in_strings = malloc(sizeof(char *) * in_strings_length);
+
+          for (int i = 0; i < in_strings_length; i++) {
+            in_strings[i] = NULL;
+          }
+
+          for (int i = 0; i < in_strings_length; i++) {
+            if (({
+                  int type;
+                  int size;
+                  ei_get_type(in_buff->buff, in_buff->index, &type, &size);
+                  size = size + 1; // for NULL byte
+                  in_strings[i] = malloc(sizeof(char) * size);
+                  ei_decode_string(in_buff->buff, in_buff->index,
+                                   in_strings[i]);
+                })) {
+              result =
+                  unifex_raise(env, "Unifex CNode: cannot parse argument "
+                                    "'in_strings' of type '{:list, :string}'");
+              goto exit_test_list_of_strings_caller;
+            }
+          }
+        } else if (type == ERL_STRING_EXT) {
+          char *p = malloc(sizeof(char) * in_strings_length);
+          res = ei_decode_string(in_buff->buff, in_buff->index, p);
+          in_strings = malloc(sizeof(int) * in_strings_length);
+          for (int i = 0; i < in_strings_length; i++) {
+#ifdef __CHAR_UNSIGNED
+            in_strings[i] = (int)p[i];
+#else
+            in_strings[i] = (int)p[i];
+            if (in_strings[i] < 0) {
+              in_strings[i] = in_strings[i] + 256;
+            }
+#endif
+          }
+        }
+        res;
+      })) {
+    result = unifex_raise(env, "Unifex CNode: cannot parse argument "
+                               "'in_strings' of type '{:list, :string}'");
+    goto exit_test_list_of_strings_caller;
+  }
+
+  result = test_list_of_strings(env, in_strings, in_strings_length);
+  goto exit_test_list_of_strings_caller;
+exit_test_list_of_strings_caller:
+  if (in_strings != NULL) {
+    for (int i = 0; i < in_strings_length; i++) {
+      unifex_free(in_strings[i]);
+    }
+    unifex_free(in_strings);
+  }
+
+  return result;
+}
+
+UNIFEX_TERM test_payload_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  UnifexPayload *in_payload;
+  in_payload = NULL;
   if (unifex_payload_decode(env, in_buff, &in_payload)) {
     result = unifex_raise(
         env,
         "Unifex CNode: cannot parse argument 'in_payload' of type ':payload'");
-    goto exit_foo_caller;
+    goto exit_test_payload_caller;
   }
 
-  if (({
-        state = (UnifexState *)env->state;
-        0;
-      })) {
-    result = unifex_raise(
-        env, "Unifex CNode: cannot parse argument 'state' of type ':state'");
-    goto exit_foo_caller;
-  }
-
-  result = foo(env, target, in_payload, state);
-  goto exit_foo_caller;
-exit_foo_caller:
+  result = test_payload(env, in_payload);
+  goto exit_test_payload_caller;
+exit_test_payload_caller:
   if (in_payload && !in_payload->owned) {
     unifex_payload_release(in_payload);
   }
+
+  return result;
+}
+
+UNIFEX_TERM test_pid_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  UnifexPid in_pid;
+
+  if (ei_decode_pid(in_buff->buff, in_buff->index, &in_pid)) {
+    result = unifex_raise(
+        env, "Unifex CNode: cannot parse argument 'in_pid' of type ':pid'");
+    goto exit_test_pid_caller;
+  }
+
+  result = test_pid(env, in_pid);
+  goto exit_test_pid_caller;
+exit_test_pid_caller:
+
+  return result;
+}
+
+UNIFEX_TERM test_example_message_caller(UnifexEnv *env,
+                                        UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+  UNIFEX_UNUSED(in_buff);
+
+  result = test_example_message(env);
+  goto exit_test_example_message_caller;
+exit_test_example_message_caller:
 
   return result;
 }
@@ -115,10 +390,7 @@ int send_example_msg(UnifexEnv *env, UnifexPid pid, int flags, int num) {
 
   ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "example_msg");
-  ({
-    int num_int = num;
-    ei_x_encode_longlong(out_buff, (long long)num_int);
-  });
+  ({ ei_x_encode_longlong(out_buff, (long long)num); });
 
   unifex_cnode_send_and_free(env, &pid, out_buff);
   return 1;
@@ -128,8 +400,20 @@ UNIFEX_TERM unifex_cnode_handle_message(UnifexEnv *env, char *fun_name,
                                         UnifexCNodeInBuff *in_buff) {
   if (strcmp(fun_name, "init") == 0) {
     return init_caller(env, in_buff);
-  } else if (strcmp(fun_name, "foo") == 0) {
-    return foo_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_uint") == 0) {
+    return test_uint_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_string") == 0) {
+    return test_string_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_list") == 0) {
+    return test_list_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_list_of_strings") == 0) {
+    return test_list_of_strings_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_payload") == 0) {
+    return test_payload_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_pid") == 0) {
+    return test_pid_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_example_message") == 0) {
+    return test_example_message_caller(env, in_buff);
   } else {
     return unifex_cnode_undefined_function_error(env, fun_name);
   }

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -286,7 +286,6 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   unsigned int in_list_length;
   in_list = NULL;
   if (({
-        int res = 1;
         int type;
         int size;
 
@@ -304,8 +303,8 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
           unifex_buff.buff = in_buff->buff;
           unifex_buff.index = in_buff->index;
         }
-        res = ei_decode_list_header(unifex_buff_ptr->buff,
-                                    unifex_buff_ptr->index, &size);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         in_list_length = (unsigned int)size;
         in_list = malloc(sizeof(int) * in_list_length);
 
@@ -328,7 +327,6 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         }
         ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                               &size);
-        res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "
                                "of type '{:list, :int}'");
@@ -355,7 +353,6 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
   unsigned int in_strings_length;
   in_strings = NULL;
   if (({
-        int res = 1;
         int type;
         int size;
 
@@ -374,8 +371,8 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
           unifex_buff.buff = in_buff->buff;
           unifex_buff.index = in_buff->index;
         }
-        res = ei_decode_list_header(unifex_buff_ptr->buff,
-                                    unifex_buff_ptr->index, &size);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         in_strings_length = (unsigned int)size;
         in_strings = malloc(sizeof(char *) * in_strings_length);
 
@@ -402,7 +399,6 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
         }
         ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                               &size);
-        res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument "
                                "'in_strings' of type '{:list, :string}'");
@@ -430,7 +426,6 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
   unsigned int in_uints_length;
   in_uints = NULL;
   if (({
-        int res = 1;
         int type;
         int size;
 
@@ -449,8 +444,8 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
           unifex_buff.buff = in_buff->buff;
           unifex_buff.index = in_buff->index;
         }
-        res = ei_decode_list_header(unifex_buff_ptr->buff,
-                                    unifex_buff_ptr->index, &size);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         in_uints_length = (unsigned int)size;
         in_uints = malloc(sizeof(unsigned int) * in_uints_length);
 
@@ -474,7 +469,6 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         }
         ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                               &size);
-        res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_uints' "
                                "of type '{:list, :unsigned}'");
@@ -503,7 +497,6 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
   in_list = NULL;
   other_param = NULL;
   if (({
-        int res = 1;
         int type;
         int size;
 
@@ -521,8 +514,8 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
           unifex_buff.buff = in_buff->buff;
           unifex_buff.index = in_buff->index;
         }
-        res = ei_decode_list_header(unifex_buff_ptr->buff,
-                                    unifex_buff_ptr->index, &size);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         in_list_length = (unsigned int)size;
         in_list = malloc(sizeof(int) * in_list_length);
 
@@ -545,7 +538,6 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         }
         ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                               &size);
-        res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "
                                "of type '{:list, :int}'");

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -302,6 +302,7 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
           unifex_buff->buff = buff.buff;
           *unifex_buff->index = 0;
         } else {
+          free(unifex_buff->index);
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
         }
@@ -327,8 +328,10 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
             goto exit_test_list_caller;
           }
         }
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        if (type == ERL_STRING_EXT) {
+          free(unifex_buff->index);
+        }
         free(unifex_buff);
         res;
       })) {
@@ -374,6 +377,7 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
           unifex_buff->buff = buff.buff;
           *unifex_buff->index = 0;
         } else {
+          free(unifex_buff->index);
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
         }
@@ -404,8 +408,10 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
             goto exit_test_list_of_strings_caller;
           }
         }
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        if (type == ERL_STRING_EXT) {
+          free(unifex_buff->index);
+        }
         free(unifex_buff);
         res;
       })) {
@@ -452,6 +458,7 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
           unifex_buff->buff = buff.buff;
           *unifex_buff->index = 0;
         } else {
+          free(unifex_buff->index);
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
         }
@@ -478,8 +485,10 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
             goto exit_test_list_of_uints_caller;
           }
         }
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        if (type == ERL_STRING_EXT) {
+          free(unifex_buff->index);
+        }
         free(unifex_buff);
         res;
       })) {
@@ -526,6 +535,7 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
           unifex_buff->buff = buff.buff;
           *unifex_buff->index = 0;
         } else {
+          free(unifex_buff->index);
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
         }
@@ -551,8 +561,10 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
             goto exit_test_list_with_other_args_caller;
           }
         }
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        if (type == ERL_STRING_EXT) {
+          free(unifex_buff->index);
+        }
         free(unifex_buff);
         res;
       })) {

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -293,27 +293,14 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_list_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff;
-        unifex_buff = malloc(sizeof(UnifexCNodeInBuff));
+        UnifexCNodeInBuff *unifex_buff =
+            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
+        unifex_buff->index = (int *)malloc(sizeof(int));
+
         if (type == ERL_STRING_EXT) {
-          char *p = malloc(sizeof(char) * in_list_length);
-          res = ei_decode_string(in_buff->buff, in_buff->index, p);
-          unsigned char *unsigned_p = (unsigned char *)p;
-
-          ei_x_buff buff;
-          ei_x_new_with_version(&buff);
-          ei_x_encode_list_header(&buff, in_list_length);
-          for (unsigned int i = 0; i < in_list_length; i++) {
-            ei_x_encode_ulong(&buff, (unsigned long)unsigned_p[i]);
-          }
-          ei_x_encode_empty_list(&buff);
-
-          int version;
-          int index = 0;
-          ei_decode_version(buff.buff, &index, &version);
-          res = ei_get_type(buff.buff, &index, &type, &size);
+          ei_x_buff buff = unifex_cnode_string_to_list(in_buff, in_list_length);
           unifex_buff->buff = buff.buff;
-          unifex_buff->index = &index;
+          *unifex_buff->index = 0;
         } else {
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
@@ -340,7 +327,9 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
             goto exit_test_list_caller;
           }
         }
-        res = ei_skip_term(unifex_buff->buff, unifex_buff->index);
+        res =
+            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        free(unifex_buff);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "
@@ -375,27 +364,15 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_strings_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff;
-        unifex_buff = malloc(sizeof(UnifexCNodeInBuff));
+        UnifexCNodeInBuff *unifex_buff =
+            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
+        unifex_buff->index = (int *)malloc(sizeof(int));
+
         if (type == ERL_STRING_EXT) {
-          char *p = malloc(sizeof(char) * in_strings_length);
-          res = ei_decode_string(in_buff->buff, in_buff->index, p);
-          unsigned char *unsigned_p = (unsigned char *)p;
-
-          ei_x_buff buff;
-          ei_x_new_with_version(&buff);
-          ei_x_encode_list_header(&buff, in_strings_length);
-          for (unsigned int i = 0; i < in_strings_length; i++) {
-            ei_x_encode_ulong(&buff, (unsigned long)unsigned_p[i]);
-          }
-          ei_x_encode_empty_list(&buff);
-
-          int version;
-          int index = 0;
-          ei_decode_version(buff.buff, &index, &version);
-          res = ei_get_type(buff.buff, &index, &type, &size);
+          ei_x_buff buff =
+              unifex_cnode_string_to_list(in_buff, in_strings_length);
           unifex_buff->buff = buff.buff;
-          unifex_buff->index = &index;
+          *unifex_buff->index = 0;
         } else {
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
@@ -427,7 +404,9 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
             goto exit_test_list_of_strings_caller;
           }
         }
-        res = ei_skip_term(unifex_buff->buff, unifex_buff->index);
+        res =
+            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        free(unifex_buff);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument "
@@ -463,27 +442,15 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_uints_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff;
-        unifex_buff = malloc(sizeof(UnifexCNodeInBuff));
+        UnifexCNodeInBuff *unifex_buff =
+            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
+        unifex_buff->index = (int *)malloc(sizeof(int));
+
         if (type == ERL_STRING_EXT) {
-          char *p = malloc(sizeof(char) * in_uints_length);
-          res = ei_decode_string(in_buff->buff, in_buff->index, p);
-          unsigned char *unsigned_p = (unsigned char *)p;
-
-          ei_x_buff buff;
-          ei_x_new_with_version(&buff);
-          ei_x_encode_list_header(&buff, in_uints_length);
-          for (unsigned int i = 0; i < in_uints_length; i++) {
-            ei_x_encode_ulong(&buff, (unsigned long)unsigned_p[i]);
-          }
-          ei_x_encode_empty_list(&buff);
-
-          int version;
-          int index = 0;
-          ei_decode_version(buff.buff, &index, &version);
-          res = ei_get_type(buff.buff, &index, &type, &size);
+          ei_x_buff buff =
+              unifex_cnode_string_to_list(in_buff, in_uints_length);
           unifex_buff->buff = buff.buff;
-          unifex_buff->index = &index;
+          *unifex_buff->index = 0;
         } else {
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
@@ -511,7 +478,9 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
             goto exit_test_list_of_uints_caller;
           }
         }
-        res = ei_skip_term(unifex_buff->buff, unifex_buff->index);
+        res =
+            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        free(unifex_buff);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_uints' "
@@ -548,27 +517,14 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_list_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff;
-        unifex_buff = malloc(sizeof(UnifexCNodeInBuff));
+        UnifexCNodeInBuff *unifex_buff =
+            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
+        unifex_buff->index = (int *)malloc(sizeof(int));
+
         if (type == ERL_STRING_EXT) {
-          char *p = malloc(sizeof(char) * in_list_length);
-          res = ei_decode_string(in_buff->buff, in_buff->index, p);
-          unsigned char *unsigned_p = (unsigned char *)p;
-
-          ei_x_buff buff;
-          ei_x_new_with_version(&buff);
-          ei_x_encode_list_header(&buff, in_list_length);
-          for (unsigned int i = 0; i < in_list_length; i++) {
-            ei_x_encode_ulong(&buff, (unsigned long)unsigned_p[i]);
-          }
-          ei_x_encode_empty_list(&buff);
-
-          int version;
-          int index = 0;
-          ei_decode_version(buff.buff, &index, &version);
-          res = ei_get_type(buff.buff, &index, &type, &size);
+          ei_x_buff buff = unifex_cnode_string_to_list(in_buff, in_list_length);
           unifex_buff->buff = buff.buff;
-          unifex_buff->index = &index;
+          *unifex_buff->index = 0;
         } else {
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
@@ -595,7 +551,9 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
             goto exit_test_list_with_other_args_caller;
           }
         }
-        res = ei_skip_term(unifex_buff->buff, unifex_buff->index);
+        res =
+            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        free(unifex_buff);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -293,22 +293,19 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_list_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff =
-            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
-        unifex_buff->index = (int *)malloc(sizeof(int));
-
+        int index = 0;
+        UnifexCNodeInBuff unifex_buff;
+        UnifexCNodeInBuff *unifex_buff_ptr = &unifex_buff;
         if (type == ERL_STRING_EXT) {
           ei_x_buff buff = unifex_cnode_string_to_list(in_buff, in_list_length);
-          unifex_buff->buff = buff.buff;
-          *unifex_buff->index = 0;
+          unifex_buff.buff = buff.buff;
+          unifex_buff.index = &index;
         } else {
-          free(unifex_buff->index);
-          unifex_buff->buff = in_buff->buff;
-          unifex_buff->index = in_buff->index;
+          unifex_buff.buff = in_buff->buff;
+          unifex_buff.index = in_buff->index;
         }
-
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        res = ei_decode_list_header(unifex_buff_ptr->buff,
+                                    unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
         in_list = malloc(sizeof(int) * in_list_length);
 
@@ -318,8 +315,9 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         for (unsigned int i = 0; i < in_list_length; i++) {
           if (({
                 long long tmp_longlong;
-                int result = ei_decode_longlong(
-                    unifex_buff->buff, unifex_buff->index, &tmp_longlong);
+                int result =
+                    ei_decode_longlong(unifex_buff_ptr->buff,
+                                       unifex_buff_ptr->index, &tmp_longlong);
                 in_list[i] = (int)tmp_longlong;
                 result;
               })) {
@@ -328,11 +326,8 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
             goto exit_test_list_caller;
           }
         }
-        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
-        if (type == ERL_STRING_EXT) {
-          free(unifex_buff->index);
-        }
-        free(unifex_buff);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "
@@ -367,23 +362,20 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_strings_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff =
-            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
-        unifex_buff->index = (int *)malloc(sizeof(int));
-
+        int index = 0;
+        UnifexCNodeInBuff unifex_buff;
+        UnifexCNodeInBuff *unifex_buff_ptr = &unifex_buff;
         if (type == ERL_STRING_EXT) {
           ei_x_buff buff =
               unifex_cnode_string_to_list(in_buff, in_strings_length);
-          unifex_buff->buff = buff.buff;
-          *unifex_buff->index = 0;
+          unifex_buff.buff = buff.buff;
+          unifex_buff.index = &index;
         } else {
-          free(unifex_buff->index);
-          unifex_buff->buff = in_buff->buff;
-          unifex_buff->index = in_buff->index;
+          unifex_buff.buff = in_buff->buff;
+          unifex_buff.index = in_buff->index;
         }
-
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        res = ei_decode_list_header(unifex_buff_ptr->buff,
+                                    unifex_buff_ptr->index, &size);
         in_strings_length = (unsigned int)size;
         in_strings = malloc(sizeof(char *) * in_strings_length);
 
@@ -395,11 +387,11 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
           if (({
                 int type;
                 int size;
-                ei_get_type(unifex_buff->buff, unifex_buff->index, &type,
-                            &size);
+                ei_get_type(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                            &type, &size);
                 size = size + 1; // for NULL byte
                 in_strings[i] = malloc(sizeof(char) * size);
-                ei_decode_string(unifex_buff->buff, unifex_buff->index,
+                ei_decode_string(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                                  in_strings[i]);
               })) {
             result =
@@ -408,11 +400,8 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
             goto exit_test_list_of_strings_caller;
           }
         }
-        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
-        if (type == ERL_STRING_EXT) {
-          free(unifex_buff->index);
-        }
-        free(unifex_buff);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument "
@@ -448,23 +437,20 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_uints_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff =
-            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
-        unifex_buff->index = (int *)malloc(sizeof(int));
-
+        int index = 0;
+        UnifexCNodeInBuff unifex_buff;
+        UnifexCNodeInBuff *unifex_buff_ptr = &unifex_buff;
         if (type == ERL_STRING_EXT) {
           ei_x_buff buff =
               unifex_cnode_string_to_list(in_buff, in_uints_length);
-          unifex_buff->buff = buff.buff;
-          *unifex_buff->index = 0;
+          unifex_buff.buff = buff.buff;
+          unifex_buff.index = &index;
         } else {
-          free(unifex_buff->index);
-          unifex_buff->buff = in_buff->buff;
-          unifex_buff->index = in_buff->index;
+          unifex_buff.buff = in_buff->buff;
+          unifex_buff.index = in_buff->index;
         }
-
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        res = ei_decode_list_header(unifex_buff_ptr->buff,
+                                    unifex_buff_ptr->index, &size);
         in_uints_length = (unsigned int)size;
         in_uints = malloc(sizeof(unsigned int) * in_uints_length);
 
@@ -474,8 +460,9 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         for (unsigned int i = 0; i < in_uints_length; i++) {
           if (({
                 unsigned long long tmp_ulonglong;
-                int result = ei_decode_ulonglong(
-                    unifex_buff->buff, unifex_buff->index, &tmp_ulonglong);
+                int result =
+                    ei_decode_ulonglong(unifex_buff_ptr->buff,
+                                        unifex_buff_ptr->index, &tmp_ulonglong);
                 in_uints[i] = (unsigned int)tmp_ulonglong;
                 result;
               })) {
@@ -485,11 +472,8 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
             goto exit_test_list_of_uints_caller;
           }
         }
-        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
-        if (type == ERL_STRING_EXT) {
-          free(unifex_buff->index);
-        }
-        free(unifex_buff);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_uints' "
@@ -526,22 +510,19 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         in_list_length = (unsigned int)size;
 
-        UnifexCNodeInBuff *unifex_buff =
-            (UnifexCNodeInBuff *)malloc(sizeof(UnifexCNodeInBuff));
-        unifex_buff->index = (int *)malloc(sizeof(int));
-
+        int index = 0;
+        UnifexCNodeInBuff unifex_buff;
+        UnifexCNodeInBuff *unifex_buff_ptr = &unifex_buff;
         if (type == ERL_STRING_EXT) {
           ei_x_buff buff = unifex_cnode_string_to_list(in_buff, in_list_length);
-          unifex_buff->buff = buff.buff;
-          *unifex_buff->index = 0;
+          unifex_buff.buff = buff.buff;
+          unifex_buff.index = &index;
         } else {
-          free(unifex_buff->index);
-          unifex_buff->buff = in_buff->buff;
-          unifex_buff->index = in_buff->index;
+          unifex_buff.buff = in_buff->buff;
+          unifex_buff.index = in_buff->index;
         }
-
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        res = ei_decode_list_header(unifex_buff_ptr->buff,
+                                    unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
         in_list = malloc(sizeof(int) * in_list_length);
 
@@ -551,8 +532,9 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         for (unsigned int i = 0; i < in_list_length; i++) {
           if (({
                 long long tmp_longlong;
-                int result = ei_decode_longlong(
-                    unifex_buff->buff, unifex_buff->index, &tmp_longlong);
+                int result =
+                    ei_decode_longlong(unifex_buff_ptr->buff,
+                                       unifex_buff_ptr->index, &tmp_longlong);
                 in_list[i] = (int)tmp_longlong;
                 result;
               })) {
@@ -561,11 +543,8 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
             goto exit_test_list_with_other_args_caller;
           }
         }
-        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
-        if (type == ERL_STRING_EXT) {
-          free(unifex_buff->index);
-        }
-        free(unifex_buff);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -28,24 +28,101 @@ UNIFEX_TERM init_result_ok(UnifexEnv *env, UnifexState *state) {
   return out_buff;
 }
 
-UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer,
-                          UnifexPayload *out_payload) {
+UNIFEX_TERM test_uint_result_ok(UnifexEnv *env, unsigned int out_uint) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
 
-  ei_x_encode_tuple_header(out_buff, 3);
+  ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "ok");
   ({
-    int answer_int = answer;
-    ei_x_encode_longlong(out_buff, (long long)answer_int);
+    unsigned int out_uint_uint = out_uint;
+    ei_x_encode_ulonglong(out_buff, (unsigned long long)out_uint_uint);
   });
 
+  return out_buff;
+}
+
+UNIFEX_TERM test_string_result_ok(UnifexEnv *env, const char *out_string) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 2);
+  ei_x_encode_atom(out_buff, "ok");
+  ei_x_encode_string(out_buff, out_string);
+
+  return out_buff;
+}
+
+UNIFEX_TERM test_list_result_ok(UnifexEnv *env, const int *out_list,
+                                int out_list_length) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 2);
+  ei_x_encode_atom(out_buff, "ok");
+  ({
+    ei_x_encode_list_header(out_buff, out_list_length);
+    for (int i = 0; i < out_list_length; i++) {
+      ({ ei_x_encode_longlong(out_buff, (long long)out_list[i]); });
+    }
+    ei_x_encode_empty_list(out_buff);
+  });
+
+  return out_buff;
+}
+
+UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env,
+                                           const char **out_strings,
+                                           int out_strings_length) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 2);
+  ei_x_encode_atom(out_buff, "ok");
+  ({
+    ei_x_encode_list_header(out_buff, out_strings_length);
+    for (int i = 0; i < out_strings_length; i++) {
+      ei_x_encode_string(out_buff, out_strings[i]);
+    }
+    ei_x_encode_empty_list(out_buff);
+  });
+
+  return out_buff;
+}
+
+UNIFEX_TERM test_payload_result_ok(UnifexEnv *env, UnifexPayload *out_payload) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 2);
+  ei_x_encode_atom(out_buff, "ok");
   unifex_payload_encode(env, out_buff, out_payload);
 
   return out_buff;
 }
 
-UNIFEX_TERM foo_result_error(UnifexEnv *env, const char *reason) {
+UNIFEX_TERM test_pid_result_ok(UnifexEnv *env) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 1);
+  ei_x_encode_atom(out_buff, "ok");
+
+  return out_buff;
+}
+
+UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 1);
+  ei_x_encode_atom(out_buff, "ok");
+
+  return out_buff;
+}
+
+UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
+                                              const char *reason) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
 
@@ -67,43 +144,241 @@ exit_init_caller:
   return result;
 }
 
-UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+UNIFEX_TERM test_uint_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   UNIFEX_TERM result;
 
-  UnifexPid target;
-  UnifexPayload *in_payload;
-  UnifexState *state;
+  unsigned int in_uint;
 
-  in_payload = NULL;
-
-  if (ei_decode_pid(in_buff->buff, in_buff->index, &target)) {
+  if (({
+        unsigned long long in_uint_ulonglong;
+        int result = ei_decode_ulonglong(in_buff->buff, in_buff->index,
+                                         &in_uint_ulonglong);
+        in_uint = (unsigned int)in_uint_ulonglong;
+        result;
+      })) {
     result = unifex_raise(
-        env, "Unifex CNode: cannot parse argument 'target' of type ':pid'");
-    goto exit_foo_caller;
+        env,
+        "Unifex CNode: cannot parse argument 'in_uint' of type ':unsigned'");
+    goto exit_test_uint_caller;
   }
 
+  result = test_uint(env, in_uint);
+  goto exit_test_uint_caller;
+exit_test_uint_caller:
+
+  return result;
+}
+
+UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  char *in_string;
+  in_string = NULL;
+  if (({
+        int type;
+        int size;
+        ei_get_type(in_buff->buff, in_buff->index, &type, &size);
+        size = size + 1; // for NULL byte
+        in_string = malloc(sizeof(char) * size);
+        ei_decode_string(in_buff->buff, in_buff->index, in_string);
+      })) {
+    result = unifex_raise(
+        env,
+        "Unifex CNode: cannot parse argument 'in_string' of type ':string'");
+    goto exit_test_string_caller;
+  }
+
+  result = test_string(env, in_string);
+  goto exit_test_string_caller;
+exit_test_string_caller:
+  unifex_free(in_string);
+  return result;
+}
+
+UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  int *in_list;
+  int in_list_length;
+  in_list = NULL;
+  if (({
+        int res = 1;
+        int type;
+        ei_get_type(in_buff->buff, in_buff->index, &type, &in_list_length);
+        if (type == ERL_LIST_EXT) {
+          res = ei_decode_list_header(in_buff->buff, in_buff->index,
+                                      &in_list_length);
+          in_list = malloc(sizeof(int) * in_list_length);
+
+          for (int i = 0; i < in_list_length; i++) {
+          }
+
+          for (int i = 0; i < in_list_length; i++) {
+            if (({
+                  long long tmp_longlong;
+                  int result = ei_decode_longlong(in_buff->buff, in_buff->index,
+                                                  &tmp_longlong);
+                  in_list[i] = (int)tmp_longlong;
+                  result;
+                })) {
+              result = unifex_raise(env, "Unifex CNode: cannot parse argument "
+                                         "'in_list' of type '{:list, :int}'");
+              goto exit_test_list_caller;
+            }
+          }
+        } else if (type == ERL_STRING_EXT) {
+          char *p = malloc(sizeof(char) * in_list_length);
+          res = ei_decode_string(in_buff->buff, in_buff->index, p);
+          in_list = malloc(sizeof(int) * in_list_length);
+          for (int i = 0; i < in_list_length; i++) {
+#ifdef __CHAR_UNSIGNED
+            in_list[i] = (int)p[i];
+#else
+            in_list[i] = (int)p[i];
+            if (in_list[i] < 0) {
+              in_list[i] = in_list[i] + 256;
+            }
+#endif
+          }
+        }
+        res;
+      })) {
+    result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "
+                               "of type '{:list, :int}'");
+    goto exit_test_list_caller;
+  }
+
+  result = test_list(env, in_list, in_list_length);
+  goto exit_test_list_caller;
+exit_test_list_caller:
+  if (in_list != NULL) {
+    for (int i = 0; i < in_list_length; i++) {
+    }
+    unifex_free(in_list);
+  }
+
+  return result;
+}
+
+UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
+                                        UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  char **in_strings;
+  int in_strings_length;
+  in_strings = NULL;
+  if (({
+        int res = 1;
+        int type;
+        ei_get_type(in_buff->buff, in_buff->index, &type, &in_strings_length);
+        if (type == ERL_LIST_EXT) {
+          res = ei_decode_list_header(in_buff->buff, in_buff->index,
+                                      &in_strings_length);
+          in_strings = malloc(sizeof(char *) * in_strings_length);
+
+          for (int i = 0; i < in_strings_length; i++) {
+            in_strings[i] = NULL;
+          }
+
+          for (int i = 0; i < in_strings_length; i++) {
+            if (({
+                  int type;
+                  int size;
+                  ei_get_type(in_buff->buff, in_buff->index, &type, &size);
+                  size = size + 1; // for NULL byte
+                  in_strings[i] = malloc(sizeof(char) * size);
+                  ei_decode_string(in_buff->buff, in_buff->index,
+                                   in_strings[i]);
+                })) {
+              result =
+                  unifex_raise(env, "Unifex CNode: cannot parse argument "
+                                    "'in_strings' of type '{:list, :string}'");
+              goto exit_test_list_of_strings_caller;
+            }
+          }
+        } else if (type == ERL_STRING_EXT) {
+          char *p = malloc(sizeof(char) * in_strings_length);
+          res = ei_decode_string(in_buff->buff, in_buff->index, p);
+          in_strings = malloc(sizeof(int) * in_strings_length);
+          for (int i = 0; i < in_strings_length; i++) {
+#ifdef __CHAR_UNSIGNED
+            in_strings[i] = (int)p[i];
+#else
+            in_strings[i] = (int)p[i];
+            if (in_strings[i] < 0) {
+              in_strings[i] = in_strings[i] + 256;
+            }
+#endif
+          }
+        }
+        res;
+      })) {
+    result = unifex_raise(env, "Unifex CNode: cannot parse argument "
+                               "'in_strings' of type '{:list, :string}'");
+    goto exit_test_list_of_strings_caller;
+  }
+
+  result = test_list_of_strings(env, in_strings, in_strings_length);
+  goto exit_test_list_of_strings_caller;
+exit_test_list_of_strings_caller:
+  if (in_strings != NULL) {
+    for (int i = 0; i < in_strings_length; i++) {
+      unifex_free(in_strings[i]);
+    }
+    unifex_free(in_strings);
+  }
+
+  return result;
+}
+
+UNIFEX_TERM test_payload_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  UnifexPayload *in_payload;
+  in_payload = NULL;
   if (unifex_payload_decode(env, in_buff, &in_payload)) {
     result = unifex_raise(
         env,
         "Unifex CNode: cannot parse argument 'in_payload' of type ':payload'");
-    goto exit_foo_caller;
+    goto exit_test_payload_caller;
   }
 
-  if (({
-        state = (UnifexState *)env->state;
-        0;
-      })) {
-    result = unifex_raise(
-        env, "Unifex CNode: cannot parse argument 'state' of type ':state'");
-    goto exit_foo_caller;
-  }
-
-  result = foo(env, target, in_payload, state);
-  goto exit_foo_caller;
-exit_foo_caller:
+  result = test_payload(env, in_payload);
+  goto exit_test_payload_caller;
+exit_test_payload_caller:
   if (in_payload && !in_payload->owned) {
     unifex_payload_release(in_payload);
   }
+
+  return result;
+}
+
+UNIFEX_TERM test_pid_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  UnifexPid in_pid;
+
+  if (ei_decode_pid(in_buff->buff, in_buff->index, &in_pid)) {
+    result = unifex_raise(
+        env, "Unifex CNode: cannot parse argument 'in_pid' of type ':pid'");
+    goto exit_test_pid_caller;
+  }
+
+  result = test_pid(env, in_pid);
+  goto exit_test_pid_caller;
+exit_test_pid_caller:
+
+  return result;
+}
+
+UNIFEX_TERM test_example_message_caller(UnifexEnv *env,
+                                        UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+  UNIFEX_UNUSED(in_buff);
+
+  result = test_example_message(env);
+  goto exit_test_example_message_caller;
+exit_test_example_message_caller:
 
   return result;
 }
@@ -115,10 +390,7 @@ int send_example_msg(UnifexEnv *env, UnifexPid pid, int flags, int num) {
 
   ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "example_msg");
-  ({
-    int num_int = num;
-    ei_x_encode_longlong(out_buff, (long long)num_int);
-  });
+  ({ ei_x_encode_longlong(out_buff, (long long)num); });
 
   unifex_cnode_send_and_free(env, &pid, out_buff);
   return 1;
@@ -128,8 +400,20 @@ UNIFEX_TERM unifex_cnode_handle_message(UnifexEnv *env, char *fun_name,
                                         UnifexCNodeInBuff *in_buff) {
   if (strcmp(fun_name, "init") == 0) {
     return init_caller(env, in_buff);
-  } else if (strcmp(fun_name, "foo") == 0) {
-    return foo_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_uint") == 0) {
+    return test_uint_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_string") == 0) {
+    return test_string_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_list") == 0) {
+    return test_list_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_list_of_strings") == 0) {
+    return test_list_of_strings_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_payload") == 0) {
+    return test_payload_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_pid") == 0) {
+    return test_pid_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_example_message") == 0) {
+    return test_example_message_caller(env, in_buff);
   } else {
     return unifex_cnode_undefined_function_error(env, fun_name);
   }

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -286,7 +286,6 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   unsigned int in_list_length;
   in_list = NULL;
   if (({
-        int res = 1;
         int type;
         int size;
 
@@ -304,8 +303,8 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
           unifex_buff.buff = in_buff->buff;
           unifex_buff.index = in_buff->index;
         }
-        res = ei_decode_list_header(unifex_buff_ptr->buff,
-                                    unifex_buff_ptr->index, &size);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         in_list_length = (unsigned int)size;
         in_list = malloc(sizeof(int) * in_list_length);
 
@@ -328,7 +327,6 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         }
         ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                               &size);
-        res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "
                                "of type '{:list, :int}'");
@@ -355,7 +353,6 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
   unsigned int in_strings_length;
   in_strings = NULL;
   if (({
-        int res = 1;
         int type;
         int size;
 
@@ -374,8 +371,8 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
           unifex_buff.buff = in_buff->buff;
           unifex_buff.index = in_buff->index;
         }
-        res = ei_decode_list_header(unifex_buff_ptr->buff,
-                                    unifex_buff_ptr->index, &size);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         in_strings_length = (unsigned int)size;
         in_strings = malloc(sizeof(char *) * in_strings_length);
 
@@ -402,7 +399,6 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
         }
         ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                               &size);
-        res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument "
                                "'in_strings' of type '{:list, :string}'");
@@ -430,7 +426,6 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
   unsigned int in_uints_length;
   in_uints = NULL;
   if (({
-        int res = 1;
         int type;
         int size;
 
@@ -449,8 +444,8 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
           unifex_buff.buff = in_buff->buff;
           unifex_buff.index = in_buff->index;
         }
-        res = ei_decode_list_header(unifex_buff_ptr->buff,
-                                    unifex_buff_ptr->index, &size);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         in_uints_length = (unsigned int)size;
         in_uints = malloc(sizeof(unsigned int) * in_uints_length);
 
@@ -474,7 +469,6 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         }
         ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                               &size);
-        res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_uints' "
                                "of type '{:list, :unsigned}'");
@@ -503,7 +497,6 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
   in_list = NULL;
   other_param = NULL;
   if (({
-        int res = 1;
         int type;
         int size;
 
@@ -521,8 +514,8 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
           unifex_buff.buff = in_buff->buff;
           unifex_buff.index = in_buff->index;
         }
-        res = ei_decode_list_header(unifex_buff_ptr->buff,
-                                    unifex_buff_ptr->index, &size);
+        ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                              &size);
         in_list_length = (unsigned int)size;
         in_list = malloc(sizeof(int) * in_list_length);
 
@@ -545,7 +538,6 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         }
         ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                               &size);
-        res;
       })) {
     result = unifex_raise(env, "Unifex CNode: cannot parse argument 'in_list' "
                                "of type '{:list, :int}'");

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -302,6 +302,7 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
           unifex_buff->buff = buff.buff;
           *unifex_buff->index = 0;
         } else {
+          free(unifex_buff->index);
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
         }
@@ -327,8 +328,10 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
             goto exit_test_list_caller;
           }
         }
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        if (type == ERL_STRING_EXT) {
+          free(unifex_buff->index);
+        }
         free(unifex_buff);
         res;
       })) {
@@ -374,6 +377,7 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
           unifex_buff->buff = buff.buff;
           *unifex_buff->index = 0;
         } else {
+          free(unifex_buff->index);
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
         }
@@ -404,8 +408,10 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
             goto exit_test_list_of_strings_caller;
           }
         }
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        if (type == ERL_STRING_EXT) {
+          free(unifex_buff->index);
+        }
         free(unifex_buff);
         res;
       })) {
@@ -452,6 +458,7 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
           unifex_buff->buff = buff.buff;
           *unifex_buff->index = 0;
         } else {
+          free(unifex_buff->index);
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
         }
@@ -478,8 +485,10 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
             goto exit_test_list_of_uints_caller;
           }
         }
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        if (type == ERL_STRING_EXT) {
+          free(unifex_buff->index);
+        }
         free(unifex_buff);
         res;
       })) {
@@ -526,6 +535,7 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
           unifex_buff->buff = buff.buff;
           *unifex_buff->index = 0;
         } else {
+          free(unifex_buff->index);
           unifex_buff->buff = in_buff->buff;
           unifex_buff->index = in_buff->index;
         }
@@ -551,8 +561,10 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
             goto exit_test_list_with_other_args_caller;
           }
         }
-        res =
-            ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        ei_decode_list_header(unifex_buff->buff, unifex_buff->index, &size);
+        if (type == ERL_STRING_EXT) {
+          free(unifex_buff->index);
+        }
         free(unifex_buff);
         res;
       })) {

--- a/test/fixtures/cnode_ref_generated/cnode/example.h
+++ b/test/fixtures/cnode_ref_generated/cnode/example.h
@@ -29,14 +29,37 @@ void unifex_release_state(UnifexEnv *env, UnifexState *state);
 void handle_destroy_state(UnifexEnv *env, UnifexState *state);
 
 UNIFEX_TERM init(UnifexEnv *env);
-UNIFEX_TERM foo(UnifexEnv *env, UnifexPid target, UnifexPayload *in_payload,
-                UnifexState *state);
+UNIFEX_TERM test_uint(UnifexEnv *env, unsigned int in_uint);
+UNIFEX_TERM test_string(UnifexEnv *env, char *in_string);
+UNIFEX_TERM test_list(UnifexEnv *env, int *in_list, int in_list_length);
+UNIFEX_TERM test_list_of_strings(UnifexEnv *env, char **in_strings,
+                                 int in_strings_length);
+UNIFEX_TERM test_payload(UnifexEnv *env, UnifexPayload *in_payload);
+UNIFEX_TERM test_pid(UnifexEnv *env, UnifexPid in_pid);
+UNIFEX_TERM test_example_message(UnifexEnv *env);
 UNIFEX_TERM init_result_ok(UnifexEnv *env, UnifexState *state);
-UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer,
-                          UnifexPayload *out_payload);
-UNIFEX_TERM foo_result_error(UnifexEnv *env, const char *reason);
+UNIFEX_TERM test_uint_result_ok(UnifexEnv *env, unsigned int out_uint);
+UNIFEX_TERM test_string_result_ok(UnifexEnv *env, const char *out_string);
+UNIFEX_TERM test_list_result_ok(UnifexEnv *env, const int *out_list,
+                                int out_list_length);
+UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env,
+                                           const char **out_strings,
+                                           int out_strings_length);
+UNIFEX_TERM test_payload_result_ok(UnifexEnv *env, UnifexPayload *out_payload);
+UNIFEX_TERM test_pid_result_ok(UnifexEnv *env);
+UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env);
+UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
+                                              const char *reason);
 UNIFEX_TERM init_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
-UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_uint_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
+                                        UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_payload_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_pid_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_example_message_caller(UnifexEnv *env,
+                                        UnifexCNodeInBuff *in_buff);
 int send_example_msg(UnifexEnv *env, UnifexPid pid, int flags, int num);
 int handle_main(int argc, char **argv);
 

--- a/test/fixtures/cnode_ref_generated/cnode/example.h
+++ b/test/fixtures/cnode_ref_generated/cnode/example.h
@@ -38,6 +38,9 @@ UNIFEX_TERM test_list_of_strings(UnifexEnv *env, char **in_strings,
                                  unsigned int in_strings_length);
 UNIFEX_TERM test_list_of_uints(UnifexEnv *env, unsigned int *in_uints,
                                unsigned int in_uints_length);
+UNIFEX_TERM test_list_with_other_args(UnifexEnv *env, int *in_list,
+                                      unsigned int in_list_length,
+                                      char *other_param);
 UNIFEX_TERM test_payload(UnifexEnv *env, UnifexPayload *in_payload);
 UNIFEX_TERM test_pid(UnifexEnv *env, UnifexPid in_pid);
 UNIFEX_TERM test_example_message(UnifexEnv *env);
@@ -53,6 +56,10 @@ UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env,
 UNIFEX_TERM test_list_of_uints_result_ok(UnifexEnv *env,
                                          const unsigned int *out_uints,
                                          unsigned int out_uints_length);
+UNIFEX_TERM test_list_with_other_args_result_ok(UnifexEnv *env,
+                                                const int *out_list,
+                                                unsigned int out_list_length,
+                                                const char *other_param);
 UNIFEX_TERM test_payload_result_ok(UnifexEnv *env, UnifexPayload *out_payload);
 UNIFEX_TERM test_pid_result_ok(UnifexEnv *env, UnifexPid out_pid);
 UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env);
@@ -67,6 +74,8 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
                                         UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
                                       UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
+                                             UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_payload_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_pid_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_example_message_caller(UnifexEnv *env,

--- a/test/fixtures/cnode_ref_generated/cnode/example.h
+++ b/test/fixtures/cnode_ref_generated/cnode/example.h
@@ -31,9 +31,12 @@ void handle_destroy_state(UnifexEnv *env, UnifexState *state);
 UNIFEX_TERM init(UnifexEnv *env);
 UNIFEX_TERM test_uint(UnifexEnv *env, unsigned int in_uint);
 UNIFEX_TERM test_string(UnifexEnv *env, char *in_string);
-UNIFEX_TERM test_list(UnifexEnv *env, int *in_list, int in_list_length);
+UNIFEX_TERM test_list(UnifexEnv *env, int *in_list,
+                      unsigned int in_list_length);
 UNIFEX_TERM test_list_of_strings(UnifexEnv *env, char **in_strings,
-                                 int in_strings_length);
+                                 unsigned int in_strings_length);
+UNIFEX_TERM test_list_of_uints(UnifexEnv *env, unsigned int *in_uints,
+                               unsigned int in_uints_length);
 UNIFEX_TERM test_payload(UnifexEnv *env, UnifexPayload *in_payload);
 UNIFEX_TERM test_pid(UnifexEnv *env, UnifexPid in_pid);
 UNIFEX_TERM test_example_message(UnifexEnv *env);
@@ -41,10 +44,13 @@ UNIFEX_TERM init_result_ok(UnifexEnv *env, UnifexState *state);
 UNIFEX_TERM test_uint_result_ok(UnifexEnv *env, unsigned int out_uint);
 UNIFEX_TERM test_string_result_ok(UnifexEnv *env, const char *out_string);
 UNIFEX_TERM test_list_result_ok(UnifexEnv *env, const int *out_list,
-                                int out_list_length);
+                                unsigned int out_list_length);
 UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env,
                                            const char **out_strings,
-                                           int out_strings_length);
+                                           unsigned int out_strings_length);
+UNIFEX_TERM test_list_of_uints_result_ok(UnifexEnv *env,
+                                         const unsigned int *out_uints,
+                                         unsigned int out_uints_length);
 UNIFEX_TERM test_payload_result_ok(UnifexEnv *env, UnifexPayload *out_payload);
 UNIFEX_TERM test_pid_result_ok(UnifexEnv *env);
 UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env);
@@ -56,6 +62,8 @@ UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
                                         UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
+                                      UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_payload_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_pid_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_example_message_caller(UnifexEnv *env,

--- a/test/fixtures/cnode_ref_generated/cnode/example.h
+++ b/test/fixtures/cnode_ref_generated/cnode/example.h
@@ -29,6 +29,7 @@ void unifex_release_state(UnifexEnv *env, UnifexState *state);
 void handle_destroy_state(UnifexEnv *env, UnifexState *state);
 
 UNIFEX_TERM init(UnifexEnv *env);
+UNIFEX_TERM test_atom(UnifexEnv *env, char *in_atom);
 UNIFEX_TERM test_uint(UnifexEnv *env, unsigned int in_uint);
 UNIFEX_TERM test_string(UnifexEnv *env, char *in_string);
 UNIFEX_TERM test_list(UnifexEnv *env, int *in_list,
@@ -41,6 +42,7 @@ UNIFEX_TERM test_payload(UnifexEnv *env, UnifexPayload *in_payload);
 UNIFEX_TERM test_pid(UnifexEnv *env, UnifexPid in_pid);
 UNIFEX_TERM test_example_message(UnifexEnv *env);
 UNIFEX_TERM init_result_ok(UnifexEnv *env, UnifexState *state);
+UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom);
 UNIFEX_TERM test_uint_result_ok(UnifexEnv *env, unsigned int out_uint);
 UNIFEX_TERM test_string_result_ok(UnifexEnv *env, const char *out_string);
 UNIFEX_TERM test_list_result_ok(UnifexEnv *env, const int *out_list,
@@ -52,11 +54,12 @@ UNIFEX_TERM test_list_of_uints_result_ok(UnifexEnv *env,
                                          const unsigned int *out_uints,
                                          unsigned int out_uints_length);
 UNIFEX_TERM test_payload_result_ok(UnifexEnv *env, UnifexPayload *out_payload);
-UNIFEX_TERM test_pid_result_ok(UnifexEnv *env);
+UNIFEX_TERM test_pid_result_ok(UnifexEnv *env, UnifexPid out_pid);
 UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env);
 UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
                                               const char *reason);
 UNIFEX_TERM init_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_atom_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_uint_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);

--- a/test/fixtures/nif_ref_generated/nif/example.c
+++ b/test/fixtures/nif_ref_generated/nif/example.c
@@ -155,7 +155,7 @@ exit_export_foo:
   if (list_in != NULL) {
     for (unsigned int i = 0; i < list_in_length; i++) {
     }
-    enif_free(list_in);
+    unifex_free(list_in);
   }
 
   return result;

--- a/test/fixtures/nif_ref_generated/nif/example.c
+++ b/test/fixtures/nif_ref_generated/nif/example.c
@@ -10,24 +10,65 @@ UNIFEX_TERM init_result_ok(UnifexEnv *env, int was_handle_load_called,
   });
 }
 
-UNIFEX_TERM foo_result_ok(UnifexEnv *env, const int *list_out,
-                          unsigned int list_out_length, int answer) {
+UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
+                                  enif_make_atom(env, out_atom)};
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
+UNIFEX_TERM test_int_result_ok(UnifexEnv *env, int out_int) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
+                                  enif_make_int(env, out_int)};
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
+UNIFEX_TERM test_list_result_ok(UnifexEnv *env, const int *out_list,
+                                unsigned int out_list_length) {
   return ({
     const ERL_NIF_TERM terms[] = {
         enif_make_atom(env, "ok"), ({
           ERL_NIF_TERM list = enif_make_list(env, 0);
-          for (int i = list_out_length - 1; i >= 0; i--) {
+          for (int i = out_list_length - 1; i >= 0; i--) {
             list =
-                enif_make_list_cell(env, enif_make_int(env, list_out[i]), list);
+                enif_make_list_cell(env, enif_make_int(env, out_list[i]), list);
           }
           list;
-        }),
-        enif_make_int(env, answer)};
-    enif_make_tuple_from_array(env, terms, 3);
+        })
+
+    };
+    enif_make_tuple_from_array(env, terms, 2);
   });
 }
 
-UNIFEX_TERM foo_result_error(UnifexEnv *env, const char *reason) {
+UNIFEX_TERM test_pid_result_ok(UnifexEnv *env, UnifexPid out_pid) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
+                                  enif_make_pid(env, &out_pid)};
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
+UNIFEX_TERM test_state_result_ok(UnifexEnv *env, UnifexState *state) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
+                                  unifex_make_resource(env, state)};
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
+UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok")};
+    enif_make_tuple_from_array(env, terms, 1);
+  });
+}
+
+UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
+                                              const char *reason) {
   return ({
     const ERL_NIF_TERM terms[] = {enif_make_atom(env, "error"),
                                   enif_make_atom(env, reason)};
@@ -101,67 +142,164 @@ exit_export_init:
   return result;
 }
 
-static ERL_NIF_TERM export_foo(ErlNifEnv *env, int argc,
-                               const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM export_test_atom(ErlNifEnv *env, int argc,
+                                     const ERL_NIF_TERM argv[]) {
   UNIFEX_UNUSED(argc);
   ERL_NIF_TERM result;
 
   UnifexEnv *unifex_env = env;
-  UnifexPid target;
-  int *list_in;
-  unsigned int list_in_length;
-  UnifexState *state;
+  char *in_atom;
 
-  list_in = NULL;
+  in_atom = NULL;
 
-  if (!enif_get_local_pid(env, argv[0], &target)) {
-    result = unifex_raise_args_error(env, "target", ":pid");
-    goto exit_export_foo;
+  if (!unifex_alloc_and_get_atom(env, argv[0], &in_atom)) {
+    result = unifex_raise_args_error(env, "in_atom", ":atom");
+    goto exit_export_test_atom;
   }
+
+  result = test_atom(unifex_env, in_atom);
+  goto exit_export_test_atom;
+exit_export_test_atom:
+  if (in_atom != NULL)
+    unifex_free(in_atom);
+  return result;
+}
+
+static ERL_NIF_TERM export_test_int(ErlNifEnv *env, int argc,
+                                    const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  int in_int;
+
+  if (!enif_get_int(env, argv[0], &in_int)) {
+    result = unifex_raise_args_error(env, "in_int", ":int");
+    goto exit_export_test_int;
+  }
+
+  result = test_int(unifex_env, in_int);
+  goto exit_export_test_int;
+exit_export_test_int:
+
+  return result;
+}
+
+static ERL_NIF_TERM export_test_list(ErlNifEnv *env, int argc,
+                                     const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  int *in_list;
+  unsigned int in_list_length;
+
+  in_list = NULL;
 
   if (!({
         int get_list_length_result =
-            enif_get_list_length(env, argv[1], &list_in_length);
+            enif_get_list_length(env, argv[0], &in_list_length);
         if (get_list_length_result) {
-          list_in = enif_alloc(sizeof(int) * list_in_length);
+          in_list = enif_alloc(sizeof(int) * in_list_length);
 
-          for (unsigned int i = 0; i < list_in_length; i++) {
+          for (unsigned int i = 0; i < in_list_length; i++) {
           }
 
-          ERL_NIF_TERM list = argv[1];
-          for (unsigned int i = 0; i < list_in_length; i++) {
+          ERL_NIF_TERM list = argv[0];
+          for (unsigned int i = 0; i < in_list_length; i++) {
             ERL_NIF_TERM elem;
             enif_get_list_cell(env, list, &elem, &list);
-            if (!enif_get_int(env, elem, &list_in[i])) {
-              result = unifex_raise_args_error(env, "list_in", "{:list, :int}");
-              goto exit_export_foo;
+            if (!enif_get_int(env, elem, &in_list[i])) {
+              result = unifex_raise_args_error(env, "in_list", "{:list, :int}");
+              goto exit_export_test_list;
             }
           }
         }
         get_list_length_result;
       })) {
-    result = unifex_raise_args_error(env, "list_in", "{:list, :int}");
-    goto exit_export_foo;
+    result = unifex_raise_args_error(env, "in_list", "{:list, :int}");
+    goto exit_export_test_list;
   }
 
-  if (!enif_get_resource(env, argv[2], STATE_RESOURCE_TYPE, (void **)&state)) {
-    result = unifex_raise_args_error(env, "state", ":state");
-    goto exit_export_foo;
-  }
-
-  result = foo(unifex_env, target, list_in, list_in_length, state);
-  goto exit_export_foo;
-exit_export_foo:
-  if (list_in != NULL) {
-    for (unsigned int i = 0; i < list_in_length; i++) {
+  result = test_list(unifex_env, in_list, in_list_length);
+  goto exit_export_test_list;
+exit_export_test_list:
+  if (in_list != NULL) {
+    for (unsigned int i = 0; i < in_list_length; i++) {
     }
-    unifex_free(list_in);
+    unifex_free(in_list);
   }
 
   return result;
 }
 
-static ErlNifFunc nif_funcs[] = {{"unifex_init", 0, export_init, 0},
-                                 {"unifex_foo", 3, export_foo, 0}};
+static ERL_NIF_TERM export_test_pid(ErlNifEnv *env, int argc,
+                                    const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  UnifexPid in_pid;
+
+  if (!enif_get_local_pid(env, argv[0], &in_pid)) {
+    result = unifex_raise_args_error(env, "in_pid", ":pid");
+    goto exit_export_test_pid;
+  }
+
+  result = test_pid(unifex_env, in_pid);
+  goto exit_export_test_pid;
+exit_export_test_pid:
+
+  return result;
+}
+
+static ERL_NIF_TERM export_test_state(ErlNifEnv *env, int argc,
+                                      const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  UnifexState *state;
+
+  if (!enif_get_resource(env, argv[0], STATE_RESOURCE_TYPE, (void **)&state)) {
+    result = unifex_raise_args_error(env, "state", ":state");
+    goto exit_export_test_state;
+  }
+
+  result = test_state(unifex_env, state);
+  goto exit_export_test_state;
+exit_export_test_state:
+
+  return result;
+}
+
+static ERL_NIF_TERM export_test_example_message(ErlNifEnv *env, int argc,
+                                                const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  UnifexPid pid;
+
+  if (!enif_get_local_pid(env, argv[0], &pid)) {
+    result = unifex_raise_args_error(env, "pid", ":pid");
+    goto exit_export_test_example_message;
+  }
+
+  result = test_example_message(unifex_env, pid);
+  goto exit_export_test_example_message;
+exit_export_test_example_message:
+
+  return result;
+}
+
+static ErlNifFunc nif_funcs[] = {
+    {"unifex_init", 0, export_init, 0},
+    {"unifex_test_atom", 1, export_test_atom, 0},
+    {"unifex_test_int", 1, export_test_int, 0},
+    {"unifex_test_list", 1, export_test_list, 0},
+    {"unifex_test_pid", 1, export_test_pid, 0},
+    {"unifex_test_state", 1, export_test_state, 0},
+    {"unifex_test_example_message", 1, export_test_example_message, 0}};
 
 ERL_NIF_INIT(Elixir.Example.Nif, nif_funcs, unifex_load_nif, NULL, NULL, NULL)

--- a/test/fixtures/nif_ref_generated/nif/example.cpp
+++ b/test/fixtures/nif_ref_generated/nif/example.cpp
@@ -155,7 +155,7 @@ exit_export_foo:
   if (list_in != NULL) {
     for (unsigned int i = 0; i < list_in_length; i++) {
     }
-    enif_free(list_in);
+    unifex_free(list_in);
   }
 
   return result;

--- a/test/fixtures/nif_ref_generated/nif/example.cpp
+++ b/test/fixtures/nif_ref_generated/nif/example.cpp
@@ -10,24 +10,65 @@ UNIFEX_TERM init_result_ok(UnifexEnv *env, int was_handle_load_called,
   });
 }
 
-UNIFEX_TERM foo_result_ok(UnifexEnv *env, const int *list_out,
-                          unsigned int list_out_length, int answer) {
+UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
+                                  enif_make_atom(env, out_atom)};
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
+UNIFEX_TERM test_int_result_ok(UnifexEnv *env, int out_int) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
+                                  enif_make_int(env, out_int)};
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
+UNIFEX_TERM test_list_result_ok(UnifexEnv *env, const int *out_list,
+                                unsigned int out_list_length) {
   return ({
     const ERL_NIF_TERM terms[] = {
         enif_make_atom(env, "ok"), ({
           ERL_NIF_TERM list = enif_make_list(env, 0);
-          for (int i = list_out_length - 1; i >= 0; i--) {
+          for (int i = out_list_length - 1; i >= 0; i--) {
             list =
-                enif_make_list_cell(env, enif_make_int(env, list_out[i]), list);
+                enif_make_list_cell(env, enif_make_int(env, out_list[i]), list);
           }
           list;
-        }),
-        enif_make_int(env, answer)};
-    enif_make_tuple_from_array(env, terms, 3);
+        })
+
+    };
+    enif_make_tuple_from_array(env, terms, 2);
   });
 }
 
-UNIFEX_TERM foo_result_error(UnifexEnv *env, const char *reason) {
+UNIFEX_TERM test_pid_result_ok(UnifexEnv *env, UnifexPid out_pid) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
+                                  enif_make_pid(env, &out_pid)};
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
+UNIFEX_TERM test_state_result_ok(UnifexEnv *env, UnifexState *state) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
+                                  unifex_make_resource(env, state)};
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
+UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok")};
+    enif_make_tuple_from_array(env, terms, 1);
+  });
+}
+
+UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
+                                              const char *reason) {
   return ({
     const ERL_NIF_TERM terms[] = {enif_make_atom(env, "error"),
                                   enif_make_atom(env, reason)};
@@ -101,67 +142,164 @@ exit_export_init:
   return result;
 }
 
-static ERL_NIF_TERM export_foo(ErlNifEnv *env, int argc,
-                               const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM export_test_atom(ErlNifEnv *env, int argc,
+                                     const ERL_NIF_TERM argv[]) {
   UNIFEX_UNUSED(argc);
   ERL_NIF_TERM result;
 
   UnifexEnv *unifex_env = env;
-  UnifexPid target;
-  int *list_in;
-  unsigned int list_in_length;
-  UnifexState *state;
+  char *in_atom;
 
-  list_in = NULL;
+  in_atom = NULL;
 
-  if (!enif_get_local_pid(env, argv[0], &target)) {
-    result = unifex_raise_args_error(env, "target", ":pid");
-    goto exit_export_foo;
+  if (!unifex_alloc_and_get_atom(env, argv[0], &in_atom)) {
+    result = unifex_raise_args_error(env, "in_atom", ":atom");
+    goto exit_export_test_atom;
   }
+
+  result = test_atom(unifex_env, in_atom);
+  goto exit_export_test_atom;
+exit_export_test_atom:
+  if (in_atom != NULL)
+    unifex_free(in_atom);
+  return result;
+}
+
+static ERL_NIF_TERM export_test_int(ErlNifEnv *env, int argc,
+                                    const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  int in_int;
+
+  if (!enif_get_int(env, argv[0], &in_int)) {
+    result = unifex_raise_args_error(env, "in_int", ":int");
+    goto exit_export_test_int;
+  }
+
+  result = test_int(unifex_env, in_int);
+  goto exit_export_test_int;
+exit_export_test_int:
+
+  return result;
+}
+
+static ERL_NIF_TERM export_test_list(ErlNifEnv *env, int argc,
+                                     const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  int *in_list;
+  unsigned int in_list_length;
+
+  in_list = NULL;
 
   if (!({
         int get_list_length_result =
-            enif_get_list_length(env, argv[1], &list_in_length);
+            enif_get_list_length(env, argv[0], &in_list_length);
         if (get_list_length_result) {
-          list_in = enif_alloc(sizeof(int) * list_in_length);
+          in_list = enif_alloc(sizeof(int) * in_list_length);
 
-          for (unsigned int i = 0; i < list_in_length; i++) {
+          for (unsigned int i = 0; i < in_list_length; i++) {
           }
 
-          ERL_NIF_TERM list = argv[1];
-          for (unsigned int i = 0; i < list_in_length; i++) {
+          ERL_NIF_TERM list = argv[0];
+          for (unsigned int i = 0; i < in_list_length; i++) {
             ERL_NIF_TERM elem;
             enif_get_list_cell(env, list, &elem, &list);
-            if (!enif_get_int(env, elem, &list_in[i])) {
-              result = unifex_raise_args_error(env, "list_in", "{:list, :int}");
-              goto exit_export_foo;
+            if (!enif_get_int(env, elem, &in_list[i])) {
+              result = unifex_raise_args_error(env, "in_list", "{:list, :int}");
+              goto exit_export_test_list;
             }
           }
         }
         get_list_length_result;
       })) {
-    result = unifex_raise_args_error(env, "list_in", "{:list, :int}");
-    goto exit_export_foo;
+    result = unifex_raise_args_error(env, "in_list", "{:list, :int}");
+    goto exit_export_test_list;
   }
 
-  if (!enif_get_resource(env, argv[2], STATE_RESOURCE_TYPE, (void **)&state)) {
-    result = unifex_raise_args_error(env, "state", ":state");
-    goto exit_export_foo;
-  }
-
-  result = foo(unifex_env, target, list_in, list_in_length, state);
-  goto exit_export_foo;
-exit_export_foo:
-  if (list_in != NULL) {
-    for (unsigned int i = 0; i < list_in_length; i++) {
+  result = test_list(unifex_env, in_list, in_list_length);
+  goto exit_export_test_list;
+exit_export_test_list:
+  if (in_list != NULL) {
+    for (unsigned int i = 0; i < in_list_length; i++) {
     }
-    unifex_free(list_in);
+    unifex_free(in_list);
   }
 
   return result;
 }
 
-static ErlNifFunc nif_funcs[] = {{"unifex_init", 0, export_init, 0},
-                                 {"unifex_foo", 3, export_foo, 0}};
+static ERL_NIF_TERM export_test_pid(ErlNifEnv *env, int argc,
+                                    const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  UnifexPid in_pid;
+
+  if (!enif_get_local_pid(env, argv[0], &in_pid)) {
+    result = unifex_raise_args_error(env, "in_pid", ":pid");
+    goto exit_export_test_pid;
+  }
+
+  result = test_pid(unifex_env, in_pid);
+  goto exit_export_test_pid;
+exit_export_test_pid:
+
+  return result;
+}
+
+static ERL_NIF_TERM export_test_state(ErlNifEnv *env, int argc,
+                                      const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  UnifexState *state;
+
+  if (!enif_get_resource(env, argv[0], STATE_RESOURCE_TYPE, (void **)&state)) {
+    result = unifex_raise_args_error(env, "state", ":state");
+    goto exit_export_test_state;
+  }
+
+  result = test_state(unifex_env, state);
+  goto exit_export_test_state;
+exit_export_test_state:
+
+  return result;
+}
+
+static ERL_NIF_TERM export_test_example_message(ErlNifEnv *env, int argc,
+                                                const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  UnifexPid pid;
+
+  if (!enif_get_local_pid(env, argv[0], &pid)) {
+    result = unifex_raise_args_error(env, "pid", ":pid");
+    goto exit_export_test_example_message;
+  }
+
+  result = test_example_message(unifex_env, pid);
+  goto exit_export_test_example_message;
+exit_export_test_example_message:
+
+  return result;
+}
+
+static ErlNifFunc nif_funcs[] = {
+    {"unifex_init", 0, export_init, 0},
+    {"unifex_test_atom", 1, export_test_atom, 0},
+    {"unifex_test_int", 1, export_test_int, 0},
+    {"unifex_test_list", 1, export_test_list, 0},
+    {"unifex_test_pid", 1, export_test_pid, 0},
+    {"unifex_test_state", 1, export_test_state, 0},
+    {"unifex_test_example_message", 1, export_test_example_message, 0}};
 
 ERL_NIF_INIT(Elixir.Example.Nif, nif_funcs, unifex_load_nif, NULL, NULL, NULL)

--- a/test/fixtures/nif_ref_generated/nif/example.h
+++ b/test/fixtures/nif_ref_generated/nif/example.h
@@ -53,8 +53,13 @@ void handle_destroy_state(UnifexEnv *env, UnifexState *state);
  */
 
 UNIFEX_TERM init(UnifexEnv *env);
-UNIFEX_TERM foo(UnifexEnv *env, UnifexPid target, int *list_in,
-                unsigned int list_in_length, UnifexState *state);
+UNIFEX_TERM test_atom(UnifexEnv *env, char *in_atom);
+UNIFEX_TERM test_int(UnifexEnv *env, int in_int);
+UNIFEX_TERM test_list(UnifexEnv *env, int *in_list,
+                      unsigned int in_list_length);
+UNIFEX_TERM test_pid(UnifexEnv *env, UnifexPid in_pid);
+UNIFEX_TERM test_state(UnifexEnv *env, UnifexState *state);
+UNIFEX_TERM test_example_message(UnifexEnv *env, UnifexPid pid);
 
 /*
  * Callbacks for nif lifecycle hooks.
@@ -70,9 +75,15 @@ int handle_load(UnifexEnv *env, void **priv_data);
 
 UNIFEX_TERM init_result_ok(UnifexEnv *env, int was_handle_load_called,
                            UnifexState *state);
-UNIFEX_TERM foo_result_ok(UnifexEnv *env, const int *list_out,
-                          unsigned int list_out_length, int answer);
-UNIFEX_TERM foo_result_error(UnifexEnv *env, const char *reason);
+UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom);
+UNIFEX_TERM test_int_result_ok(UnifexEnv *env, int out_int);
+UNIFEX_TERM test_list_result_ok(UnifexEnv *env, const int *out_list,
+                                unsigned int out_list_length);
+UNIFEX_TERM test_pid_result_ok(UnifexEnv *env, UnifexPid out_pid);
+UNIFEX_TERM test_state_result_ok(UnifexEnv *env, UnifexState *state);
+UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env);
+UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
+                                              const char *reason);
 
 /*
  * Functions that send the defined messages from Nif.

--- a/test/fixtures/unified_ref_generated/cnode/example.c
+++ b/test/fixtures/unified_ref_generated/cnode/example.c
@@ -9,7 +9,10 @@ UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
 
   ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "ok");
-  ({ ei_x_encode_longlong(out_buff, (long long)answer); });
+  ({
+    int tmp_int = answer;
+    ei_x_encode_longlong(out_buff, (long long)tmp_int);
+  });
 
   return out_buff;
 }

--- a/test/fixtures/unified_ref_generated/cnode/example.c
+++ b/test/fixtures/unified_ref_generated/cnode/example.c
@@ -9,10 +9,7 @@ UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
 
   ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "ok");
-  ({
-    int answer_int = answer;
-    ei_x_encode_longlong(out_buff, (long long)answer_int);
-  });
+  ({ ei_x_encode_longlong(out_buff, (long long)answer); });
 
   return out_buff;
 }
@@ -23,10 +20,10 @@ UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   int num;
 
   if (({
-        long long num_longlong;
+        long long tmp_longlong;
         int result =
-            ei_decode_longlong(in_buff->buff, in_buff->index, &num_longlong);
-        num = (int)num_longlong;
+            ei_decode_longlong(in_buff->buff, in_buff->index, &tmp_longlong);
+        num = (int)tmp_longlong;
         result;
       })) {
     result = unifex_raise(

--- a/test/fixtures/unified_ref_generated/cnode/example.cpp
+++ b/test/fixtures/unified_ref_generated/cnode/example.cpp
@@ -9,7 +9,10 @@ UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
 
   ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "ok");
-  ({ ei_x_encode_longlong(out_buff, (long long)answer); });
+  ({
+    int tmp_int = answer;
+    ei_x_encode_longlong(out_buff, (long long)tmp_int);
+  });
 
   return out_buff;
 }

--- a/test/fixtures/unified_ref_generated/cnode/example.cpp
+++ b/test/fixtures/unified_ref_generated/cnode/example.cpp
@@ -9,10 +9,7 @@ UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
 
   ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "ok");
-  ({
-    int answer_int = answer;
-    ei_x_encode_longlong(out_buff, (long long)answer_int);
-  });
+  ({ ei_x_encode_longlong(out_buff, (long long)answer); });
 
   return out_buff;
 }
@@ -23,10 +20,10 @@ UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   int num;
 
   if (({
-        long long num_longlong;
+        long long tmp_longlong;
         int result =
-            ei_decode_longlong(in_buff->buff, in_buff->index, &num_longlong);
-        num = (int)num_longlong;
+            ei_decode_longlong(in_buff->buff, in_buff->index, &tmp_longlong);
+        num = (int)tmp_longlong;
         result;
       })) {
     result = unifex_raise(

--- a/test_projects/cnode/c_src/example/example.c
+++ b/test_projects/cnode/c_src/example/example.c
@@ -8,6 +8,10 @@ UNIFEX_TERM init(UnifexEnv *env) {
   return res;
 }
 
+UNIFEX_TERM test_atom(UnifexEnv *env, char *in_atom) {
+  return test_atom_result_ok(env, in_atom);
+}
+
 UNIFEX_TERM test_uint(UnifexEnv *env, unsigned int in_uint) {
   return test_uint_result_ok(env, in_uint);
 }
@@ -39,7 +43,7 @@ UNIFEX_TERM test_payload(UnifexEnv *env, UnifexPayload *in_payload) {
 
 UNIFEX_TERM test_pid(UnifexEnv *env, UnifexPid in_pid) {
   UNIFEX_UNUSED(in_pid);
-  return test_pid_result_ok(env);
+  return test_pid_result_ok(env, in_pid);
 }
 
 UNIFEX_TERM test_example_message(UnifexEnv *env) {

--- a/test_projects/cnode/c_src/example/example.c
+++ b/test_projects/cnode/c_src/example/example.c
@@ -16,15 +16,15 @@ UNIFEX_TERM test_string(UnifexEnv *env, char *str) {
   return test_string_result_ok(env, str);
 }
 
-UNIFEX_TERM test_list(UnifexEnv *env, int *in_list, int list_length) {
+UNIFEX_TERM test_list(UnifexEnv *env, int *in_list, unsigned int list_length) {
   return test_list_result_ok(env, in_list, list_length);
 }
 
-UNIFEX_TERM test_list_of_strings(UnifexEnv *env, char **in_strings, int list_length) {
+UNIFEX_TERM test_list_of_strings(UnifexEnv *env, char **in_strings, unsigned int list_length) {
   return test_list_of_strings_result_ok(env, in_strings, list_length);
 }
 
-UNIFEX_TERM test_list_of_uints(UnifexEnv *env, unsigned int *in_uints, int list_length) {
+UNIFEX_TERM test_list_of_uints(UnifexEnv *env, unsigned int *in_uints, unsigned int list_length) {
   return test_list_of_uints_result_ok(env, in_uints, list_length);
 }
 

--- a/test_projects/cnode/c_src/example/example.c
+++ b/test_projects/cnode/c_src/example/example.c
@@ -8,8 +8,7 @@ UNIFEX_TERM init(UnifexEnv *env) {
   return res;
 }
 
-UNIFEX_TERM foo(UnifexEnv *env, UnifexPid pid, UnifexPayload *in_payload,
-                MyState *state) {
+UNIFEX_TERM foo(UnifexEnv *env, UnifexPid pid, UnifexPayload *in_payload, int *in_list, int list_length, MyState *state) {
   int res = send_example_msg(env, pid, 0, state->a);
   if (!res) {
     return foo_result_error(env, "send_failed");
@@ -18,9 +17,21 @@ UNIFEX_TERM foo(UnifexEnv *env, UnifexPid pid, UnifexPayload *in_payload,
       unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, in_payload->size);
   memcpy(out_payload->data, in_payload->data, out_payload->size);
   out_payload->data[0]++;
-  UNIFEX_TERM result = foo_result_ok(env, state->a, out_payload);
+  UNIFEX_TERM result = foo_result_ok(env, state->a, out_payload, in_list, list_length);
   unifex_payload_release(out_payload);
   return result;
+}
+
+UNIFEX_TERM test_list(UnifexEnv *env, int *in_list, int list_length) {
+    return test_list_result_ok(env, in_list, list_length);
+}
+
+UNIFEX_TERM test_string(UnifexEnv *env, char *str) {
+    return test_string_result_ok(env, str);
+}
+
+UNIFEX_TERM test_strings_list(UnifexEnv *env, char **str, int list_length) {
+    return test_strings_list_result_ok(env, str, list_length);
 }
 
 void handle_destroy_state(UnifexEnv *env, MyState *state) {

--- a/test_projects/cnode/c_src/example/example.c
+++ b/test_projects/cnode/c_src/example/example.c
@@ -32,6 +32,10 @@ UNIFEX_TERM test_list_of_uints(UnifexEnv *env, unsigned int *in_uints, unsigned 
   return test_list_of_uints_result_ok(env, in_uints, list_length);
 }
 
+UNIFEX_TERM test_list_with_other_args(UnifexEnv *env, int *in_list, unsigned int list_length, char *other_param) {
+  return test_list_with_other_args_result_ok(env, in_list, list_length, other_param);
+}
+
 UNIFEX_TERM test_payload(UnifexEnv *env, UnifexPayload *in_payload) {
   UnifexPayload *out_payload = unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, in_payload->size);
   memcpy(out_payload->data, in_payload->data, out_payload->size);

--- a/test_projects/cnode/c_src/example/example.c
+++ b/test_projects/cnode/c_src/example/example.c
@@ -20,8 +20,12 @@ UNIFEX_TERM test_list(UnifexEnv *env, int *in_list, int list_length) {
   return test_list_result_ok(env, in_list, list_length);
 }
 
-UNIFEX_TERM test_list_of_strings(UnifexEnv *env, char **str, int list_length) {
-  return test_list_of_strings_result_ok(env, str, list_length);
+UNIFEX_TERM test_list_of_strings(UnifexEnv *env, char **in_strings, int list_length) {
+  return test_list_of_strings_result_ok(env, in_strings, list_length);
+}
+
+UNIFEX_TERM test_list_of_uints(UnifexEnv *env, unsigned int *in_uints, int list_length) {
+  return test_list_of_uints_result_ok(env, in_uints, list_length);
 }
 
 UNIFEX_TERM test_payload(UnifexEnv *env, UnifexPayload *in_payload) {

--- a/test_projects/cnode/c_src/example/example.c
+++ b/test_projects/cnode/c_src/example/example.c
@@ -8,30 +8,42 @@ UNIFEX_TERM init(UnifexEnv *env) {
   return res;
 }
 
-UNIFEX_TERM foo(UnifexEnv *env, UnifexPid pid, UnifexPayload *in_payload, int *in_list, int list_length, MyState *state) {
-  int res = send_example_msg(env, pid, 0, state->a);
-  if (!res) {
-    return foo_result_error(env, "send_failed");
-  }
-  UnifexPayload *out_payload =
-      unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, in_payload->size);
+UNIFEX_TERM test_uint(UnifexEnv *env, unsigned int in_uint) {
+  return test_uint_result_ok(env, in_uint);
+}
+
+UNIFEX_TERM test_string(UnifexEnv *env, char *str) {
+  return test_string_result_ok(env, str);
+}
+
+UNIFEX_TERM test_list(UnifexEnv *env, int *in_list, int list_length) {
+  return test_list_result_ok(env, in_list, list_length);
+}
+
+UNIFEX_TERM test_list_of_strings(UnifexEnv *env, char **str, int list_length) {
+  return test_list_of_strings_result_ok(env, str, list_length);
+}
+
+UNIFEX_TERM test_payload(UnifexEnv *env, UnifexPayload *in_payload) {
+  UnifexPayload *out_payload = unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, in_payload->size);
   memcpy(out_payload->data, in_payload->data, out_payload->size);
   out_payload->data[0]++;
-  UNIFEX_TERM result = foo_result_ok(env, state->a, out_payload, in_list, list_length);
+  UNIFEX_TERM result = test_payload_result_ok(env, out_payload);
   unifex_payload_release(out_payload);
   return result;
 }
 
-UNIFEX_TERM test_list(UnifexEnv *env, int *in_list, int list_length) {
-    return test_list_result_ok(env, in_list, list_length);
+UNIFEX_TERM test_pid(UnifexEnv *env, UnifexPid in_pid) {
+  UNIFEX_UNUSED(in_pid);
+  return test_pid_result_ok(env);
 }
 
-UNIFEX_TERM test_string(UnifexEnv *env, char *str) {
-    return test_string_result_ok(env, str);
-}
-
-UNIFEX_TERM test_strings_list(UnifexEnv *env, char **str, int list_length) {
-    return test_strings_list_result_ok(env, str, list_length);
+UNIFEX_TERM test_example_message(UnifexEnv *env) {
+  int res = send_example_msg(env, *env->reply_to, 0, 23);
+  if (!res) {
+    return test_example_message_result_error(env, "send_failed");
+  }
+  return test_example_message_result_ok(env);
 }
 
 void handle_destroy_state(UnifexEnv *env, MyState *state) {

--- a/test_projects/cnode/c_src/example/example.spec.exs
+++ b/test_projects/cnode/c_src/example/example.spec.exs
@@ -8,6 +8,8 @@ state_type "MyState"
 
 spec init() :: {:ok :: label, state}
 
+spec test_atom(in_atom :: atom) :: {:ok :: label, out_atom :: atom}
+
 spec test_uint(in_uint :: unsigned) :: {:ok :: label, out_uint :: unsigned}
 
 spec test_string(in_string :: string) :: {:ok :: label, out_string :: string}
@@ -20,7 +22,7 @@ spec test_list_of_uints(in_uints :: [unsigned]) :: {:ok :: label, out_uints :: [
 
 spec test_payload(in_payload :: payload) :: {:ok :: label, out_payload :: payload}
 
-spec test_pid(in_pid :: pid) :: {:ok :: label}
+spec test_pid(in_pid :: pid) :: {:ok :: label, out_pid :: pid}
 
 spec test_example_message() :: {:ok :: label} | {:error :: label, reason :: atom}
 

--- a/test_projects/cnode/c_src/example/example.spec.exs
+++ b/test_projects/cnode/c_src/example/example.spec.exs
@@ -8,7 +8,13 @@ state_type "MyState"
 
 spec init() :: {:ok :: label, state}
 
-spec foo(target :: pid, in_payload :: payload, state) ::
-       {:ok :: label, answer :: int, out_payload :: payload} | {:error :: label, reason :: atom}
+spec foo(target :: pid, in_payload :: payload, in_list :: [int], state) ::
+       {:ok :: label, answer :: int, out_payload :: payload, out_list :: [int]} | {:error :: label, reason :: atom}
+
+spec test_list(in_list :: [int]) :: {:ok :: label, out_list :: [int]}
+
+spec test_string(in_string :: string) :: {:ok :: label, out_string :: string}
+
+spec test_strings_list(in_strings :: [string]) :: {:ok :: label, out_strings :: [string]}
 
 sends {:example_msg :: label, num :: int}

--- a/test_projects/cnode/c_src/example/example.spec.exs
+++ b/test_projects/cnode/c_src/example/example.spec.exs
@@ -8,13 +8,18 @@ state_type "MyState"
 
 spec init() :: {:ok :: label, state}
 
-spec foo(target :: pid, in_payload :: payload, in_list :: [int], state) ::
-       {:ok :: label, answer :: int, out_payload :: payload, out_list :: [int]} | {:error :: label, reason :: atom}
-
-spec test_list(in_list :: [int]) :: {:ok :: label, out_list :: [int]}
+spec test_uint(in_uint :: unsigned) :: {:ok :: label, out_uint :: unsigned}
 
 spec test_string(in_string :: string) :: {:ok :: label, out_string :: string}
 
-spec test_strings_list(in_strings :: [string]) :: {:ok :: label, out_strings :: [string]}
+spec test_list(in_list :: [int]) :: {:ok :: label, out_list :: [int]}
+
+spec test_list_of_strings(in_strings :: [string]) :: {:ok :: label, out_strings :: [string]}
+
+spec test_payload(in_payload :: payload) :: {:ok :: label, out_payload :: payload}
+
+spec test_pid(in_pid :: pid) :: {:ok :: label}
+
+spec test_example_message() :: {:ok :: label} | {:error :: label, reason :: atom}
 
 sends {:example_msg :: label, num :: int}

--- a/test_projects/cnode/c_src/example/example.spec.exs
+++ b/test_projects/cnode/c_src/example/example.spec.exs
@@ -16,6 +16,8 @@ spec test_list(in_list :: [int]) :: {:ok :: label, out_list :: [int]}
 
 spec test_list_of_strings(in_strings :: [string]) :: {:ok :: label, out_strings :: [string]}
 
+spec test_list_of_uints(in_uints :: [unsigned]) :: {:ok :: label, out_uints :: [unsigned]}
+
 spec test_payload(in_payload :: payload) :: {:ok :: label, out_payload :: payload}
 
 spec test_pid(in_pid :: pid) :: {:ok :: label}

--- a/test_projects/cnode/c_src/example/example.spec.exs
+++ b/test_projects/cnode/c_src/example/example.spec.exs
@@ -20,6 +20,9 @@ spec test_list_of_strings(in_strings :: [string]) :: {:ok :: label, out_strings 
 
 spec test_list_of_uints(in_uints :: [unsigned]) :: {:ok :: label, out_uints :: [unsigned]}
 
+spec test_list_with_other_args(in_list :: [int], other_param :: atom) ::
+       {:ok :: label, out_list :: [int], other_param :: atom}
+
 spec test_payload(in_payload :: payload) :: {:ok :: label, out_payload :: payload}
 
 spec test_pid(in_pid :: pid) :: {:ok :: label, out_pid :: pid}

--- a/test_projects/cnode/test/example_test.exs
+++ b/test_projects/cnode/test/example_test.exs
@@ -8,6 +8,10 @@ defmodule ExampleTest do
     [cnode: cnode]
   end
 
+  test "atom", context do
+    assert {:ok, :unifex} = Unifex.CNode.call(context[:cnode], :test_atom, [:unifex])
+  end
+
   test "unsigned int", context do
     cnode = context[:cnode]
     assert {:ok, 0} = Unifex.CNode.call(cnode, :test_uint, [0])
@@ -70,7 +74,8 @@ defmodule ExampleTest do
   end
 
   test "pid", context do
-    assert {:ok} = Unifex.CNode.call(context[:cnode], :test_pid, [self()])
+    pid = self()
+    assert {:ok, ^pid} = Unifex.CNode.call(context[:cnode], :test_pid, [pid])
   end
 
   test "example message", context do

--- a/test_projects/cnode/test/example_test.exs
+++ b/test_projects/cnode/test/example_test.exs
@@ -1,7 +1,7 @@
 defmodule ExampleTest do
   use ExUnit.Case, async: true
 
-  setup do
+  setup_all do
     require Unifex.CNode
     {:ok, cnode} = Unifex.CNode.start_link(:example)
     :ok = Unifex.CNode.call(cnode, :init)

--- a/test_projects/cnode/test/example_test.exs
+++ b/test_projects/cnode/test/example_test.exs
@@ -37,7 +37,7 @@ defmodule ExampleTest do
     0..253
     |> Enum.each(fn x ->
       list = [x, x + 1, x + 2]
-      assert {:ok, list} = Unifex.CNode.call(context[:cnode], :test_list, [list])
+      assert {:ok, ^list} = Unifex.CNode.call(context[:cnode], :test_list, [list])
     end)
   end
 

--- a/test_projects/cnode/test/example_test.exs
+++ b/test_projects/cnode/test/example_test.exs
@@ -4,22 +4,28 @@ defmodule ExampleTest do
   test "init" do
     require Unifex.CNode
     assert {:ok, cnode} = Unifex.CNode.start_link(:example)
-    assert :ok = Unifex.CNode.call(cnode, :init)
-    assert {:ok, 42, <<2, 2, 3>>, [1, 2, 3]} = Unifex.CNode.call(cnode, :foo, [self(), <<1, 2, 3>>, [1, 2, 3]])
-    assert_receive {:example_msg, 42}
 
+    test_init(cnode)
+    test_unsigned_int(cnode)
     test_string(cnode)
     test_list(cnode)
     test_list_as_string(cnode)
     test_list_of_strings(cnode)
+    test_payload(cnode)
+    test_pid(cnode)
+    test_example_message(cnode)
 
-    assert_raise RuntimeError, ~r/undefined.*function.*abc/i, fn ->
-      Unifex.CNode.call(cnode, :abc)
-    end
+    test_undefined_function(cnode)
+    test_wrong_arguments(cnode)
+  end
 
-    assert_raise RuntimeError, ~r/argument.*target.*pid/i, fn ->
-      Unifex.CNode.call(cnode, :foo, [:abc])
-    end
+  def test_init(cnode) do
+    assert :ok = Unifex.CNode.call(cnode, :init)
+  end
+
+  def test_unsigned_int(cnode) do
+    assert {:ok, 0} = Unifex.CNode.call(cnode, :test_uint, [0])
+    assert {:ok, 5} = Unifex.CNode.call(cnode, :test_uint, [5])
   end
 
   def test_string(cnode) do
@@ -53,6 +59,31 @@ defmodule ExampleTest do
   end
 
   def test_list_of_strings(cnode) do
-    assert {:ok, ['abc', 'def', 'ghi']} = Unifex.CNode.call(cnode, :test_strings_list, [['abc', 'def', 'ghi']])
+    assert {:ok, ['abc', 'def', 'ghi']} = Unifex.CNode.call(cnode, :test_list_of_strings, [['abc', 'def', 'ghi']])
+  end
+
+  def test_payload(cnode) do
+    assert {:ok, <<2, 2, 3>>} = Unifex.CNode.call(cnode, :test_payload, [<<1, 2, 3>>])
+  end
+
+  def test_pid(cnode) do
+    assert {:ok} = Unifex.CNode.call(cnode, :test_pid, [self()])
+  end
+
+  def test_example_message(cnode) do
+    assert {:ok} = Unifex.CNode.call(cnode, :test_example_message)
+    assert_receive {:example_msg, 23}
+  end
+
+  def test_undefined_function(cnode) do
+    assert_raise RuntimeError, ~r/undefined.*function.*abc/i, fn ->
+      Unifex.CNode.call(cnode, :abc)
+    end
+  end
+
+  def test_wrong_arguments(cnode) do
+    assert_raise RuntimeError, ~r/argument.*in_pid.*pid/i, fn ->
+      Unifex.CNode.call(cnode, :test_pid, [:abc])
+    end
   end
 end

--- a/test_projects/cnode/test/example_test.exs
+++ b/test_projects/cnode/test/example_test.exs
@@ -1,38 +1,31 @@
 defmodule ExampleTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
-  test "init" do
+  setup do
     require Unifex.CNode
-    assert {:ok, cnode} = Unifex.CNode.start_link(:example)
-
-    test_init(cnode)
-    test_unsigned_int(cnode)
-    test_string(cnode)
-    test_list(cnode)
-    test_list_as_string(cnode)
-    test_list_of_strings(cnode)
-    test_payload(cnode)
-    test_pid(cnode)
-    test_example_message(cnode)
-
-    test_undefined_function(cnode)
-    test_wrong_arguments(cnode)
+    {:ok, cnode} = Unifex.CNode.start_link(:example)
+    :ok = Unifex.CNode.call(cnode, :init)
+    [cnode: cnode]
   end
 
-  def test_init(cnode) do
-    assert :ok = Unifex.CNode.call(cnode, :init)
-  end
-
-  def test_unsigned_int(cnode) do
+  test "unsigned int", context do
+    cnode = context[:cnode]
     assert {:ok, 0} = Unifex.CNode.call(cnode, :test_uint, [0])
     assert {:ok, 5} = Unifex.CNode.call(cnode, :test_uint, [5])
+
+    assert_raise RuntimeError, ~r/argument.*in_uint.*unsigned/i, fn ->
+      Unifex.CNode.call(cnode, :test_uint, [-1])
+    end
   end
 
-  def test_string(cnode) do
-    big_test_string = 'unifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifex
-    unifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifex
-    unifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifex
-    '
+  test "string", context do
+    cnode = context[:cnode]
+
+    big_test_string =
+      'unifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexu
+      nifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexuni
+      fexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifex'
+
     assert {:ok, ''} = Unifex.CNode.call(cnode, :test_string, [''])
     assert {:ok, 'test_string'} = Unifex.CNode.call(cnode, :test_string, ['test_string'])
     assert {:ok, '-12345'} = Unifex.CNode.call(cnode, :test_string, ['-12345'])
@@ -40,50 +33,55 @@ defmodule ExampleTest do
     assert {:ok, big_test_string} = Unifex.CNode.call(cnode, :test_string, [big_test_string])
   end
 
-  def test_list_as_string(cnode) do
-    0..253 |> Enum.each(fn x ->
-      list = [x, x+1, x+2]
-      assert {:ok, list} = Unifex.CNode.call(cnode, :test_list, [list])
+  test "list as string", context do
+    0..253
+    |> Enum.each(fn x ->
+      list = [x, x + 1, x + 2]
+      assert {:ok, list} = Unifex.CNode.call(context[:cnode], :test_list, [list])
     end)
-    assert {:ok, [0, 0, 0]} = Unifex.CNode.call(cnode, :test_list, [[0, 0, 0]])
-    assert {:ok, [127, 127, 127]} = Unifex.CNode.call(cnode, :test_list, [[127, 127, 127]])
-    assert {:ok, [128, 128, 128]} = Unifex.CNode.call(cnode, :test_list, [[128, 128, 128]])
-    assert {:ok, [255, 255, 255]} = Unifex.CNode.call(cnode, :test_list, [[255, 255, 255]])
   end
 
-  def test_list(cnode) do
+  test "list", context do
+    cnode = context[:cnode]
     assert {:ok, [-1, -1, -1]} = Unifex.CNode.call(cnode, :test_list, [[-1, -1, -1]])
     assert {:ok, [-10, -17, -28]} = Unifex.CNode.call(cnode, :test_list, [[-10, -17, -28]])
     assert {:ok, [355, 355, 355]} = Unifex.CNode.call(cnode, :test_list, [[355, 355, 355]])
     assert {:ok, [1254, 1636, 3643]} = Unifex.CNode.call(cnode, :test_list, [[1254, 1636, 3643]])
   end
 
-  def test_list_of_strings(cnode) do
-    assert {:ok, ['abc', 'def', 'ghi']} = Unifex.CNode.call(cnode, :test_list_of_strings, [['abc', 'def', 'ghi']])
+  test "list of strings", context do
+    cnode = context[:cnode]
+    assert {:ok, ['', '', '']} = Unifex.CNode.call(cnode, :test_list_of_strings, [['', '', '']])
+
+    assert {:ok, ['1', '2', '3']} =
+             Unifex.CNode.call(cnode, :test_list_of_strings, [['1', '2', '3']])
+
+    assert {:ok, ['abc', 'def', 'ghi']} =
+             Unifex.CNode.call(cnode, :test_list_of_strings, [['abc', 'def', 'ghi']])
   end
 
-  def test_payload(cnode) do
-    assert {:ok, <<2, 2, 3>>} = Unifex.CNode.call(cnode, :test_payload, [<<1, 2, 3>>])
+  test "payload", context do
+    assert {:ok, <<2, 2, 3>>} = Unifex.CNode.call(context[:cnode], :test_payload, [<<1, 2, 3>>])
   end
 
-  def test_pid(cnode) do
-    assert {:ok} = Unifex.CNode.call(cnode, :test_pid, [self()])
+  test "pid", context do
+    assert {:ok} = Unifex.CNode.call(context[:cnode], :test_pid, [self()])
   end
 
-  def test_example_message(cnode) do
-    assert {:ok} = Unifex.CNode.call(cnode, :test_example_message)
+  test "example message", context do
+    assert {:ok} = Unifex.CNode.call(context[:cnode], :test_example_message)
     assert_receive {:example_msg, 23}
   end
 
-  def test_undefined_function(cnode) do
+  test "undefined function", context do
     assert_raise RuntimeError, ~r/undefined.*function.*abc/i, fn ->
-      Unifex.CNode.call(cnode, :abc)
+      Unifex.CNode.call(context[:cnode], :abc)
     end
   end
 
-  def test_wrong_arguments(cnode) do
+  test "wrong arguments", context do
     assert_raise RuntimeError, ~r/argument.*in_pid.*pid/i, fn ->
-      Unifex.CNode.call(cnode, :test_pid, [:abc])
+      Unifex.CNode.call(context[:cnode], :test_pid, [:abc])
     end
   end
 end

--- a/test_projects/cnode/test/example_test.exs
+++ b/test_projects/cnode/test/example_test.exs
@@ -5,8 +5,13 @@ defmodule ExampleTest do
     require Unifex.CNode
     assert {:ok, cnode} = Unifex.CNode.start_link(:example)
     assert :ok = Unifex.CNode.call(cnode, :init)
-    assert {:ok, 42, <<2, 2, 3>>} = Unifex.CNode.call(cnode, :foo, [self(), <<1, 2, 3>>])
+    assert {:ok, 42, <<2, 2, 3>>, [1, 2, 3]} = Unifex.CNode.call(cnode, :foo, [self(), <<1, 2, 3>>, [1, 2, 3]])
     assert_receive {:example_msg, 42}
+
+    test_string(cnode)
+    test_list(cnode)
+    test_list_as_string(cnode)
+    test_list_of_strings(cnode)
 
     assert_raise RuntimeError, ~r/undefined.*function.*abc/i, fn ->
       Unifex.CNode.call(cnode, :abc)
@@ -15,5 +20,39 @@ defmodule ExampleTest do
     assert_raise RuntimeError, ~r/argument.*target.*pid/i, fn ->
       Unifex.CNode.call(cnode, :foo, [:abc])
     end
+  end
+
+  def test_string(cnode) do
+    big_test_string = 'unifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifex
+    unifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifex
+    unifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifex
+    '
+    assert {:ok, ''} = Unifex.CNode.call(cnode, :test_string, [''])
+    assert {:ok, 'test_string'} = Unifex.CNode.call(cnode, :test_string, ['test_string'])
+    assert {:ok, '-12345'} = Unifex.CNode.call(cnode, :test_string, ['-12345'])
+    assert {:ok, '255'} = Unifex.CNode.call(cnode, :test_string, ['255'])
+    assert {:ok, big_test_string} = Unifex.CNode.call(cnode, :test_string, [big_test_string])
+  end
+
+  def test_list_as_string(cnode) do
+    0..253 |> Enum.each(fn x ->
+      list = [x, x+1, x+2]
+      assert {:ok, list} = Unifex.CNode.call(cnode, :test_list, [list])
+    end)
+    assert {:ok, [0, 0, 0]} = Unifex.CNode.call(cnode, :test_list, [[0, 0, 0]])
+    assert {:ok, [127, 127, 127]} = Unifex.CNode.call(cnode, :test_list, [[127, 127, 127]])
+    assert {:ok, [128, 128, 128]} = Unifex.CNode.call(cnode, :test_list, [[128, 128, 128]])
+    assert {:ok, [255, 255, 255]} = Unifex.CNode.call(cnode, :test_list, [[255, 255, 255]])
+  end
+
+  def test_list(cnode) do
+    assert {:ok, [-1, -1, -1]} = Unifex.CNode.call(cnode, :test_list, [[-1, -1, -1]])
+    assert {:ok, [-10, -17, -28]} = Unifex.CNode.call(cnode, :test_list, [[-10, -17, -28]])
+    assert {:ok, [355, 355, 355]} = Unifex.CNode.call(cnode, :test_list, [[355, 355, 355]])
+    assert {:ok, [1254, 1636, 3643]} = Unifex.CNode.call(cnode, :test_list, [[1254, 1636, 3643]])
+  end
+
+  def test_list_of_strings(cnode) do
+    assert {:ok, ['abc', 'def', 'ghi']} = Unifex.CNode.call(cnode, :test_strings_list, [['abc', 'def', 'ghi']])
   end
 end

--- a/test_projects/cnode/test/example_test.exs
+++ b/test_projects/cnode/test/example_test.exs
@@ -69,6 +69,16 @@ defmodule ExampleTest do
     assert {:ok, [0, 1, 2]} = Unifex.CNode.call(cnode, :test_list_of_uints, [[0, 1, 2]])
   end
 
+  test "list with other arguments", context do
+    cnode = context[:cnode]
+
+    assert {:ok, [1, 2, 3], :other_arg} =
+             Unifex.CNode.call(cnode, :test_list_with_other_args, [[1, 2, 3], :other_arg])
+
+    assert {:ok, [300, 400, 500], :other_arg} =
+             Unifex.CNode.call(cnode, :test_list_with_other_args, [[300, 400, 500], :other_arg])
+  end
+
   test "payload", context do
     assert {:ok, <<2, 2, 3>>} = Unifex.CNode.call(context[:cnode], :test_payload, [<<1, 2, 3>>])
   end

--- a/test_projects/cnode/test/example_test.exs
+++ b/test_projects/cnode/test/example_test.exs
@@ -60,6 +60,11 @@ defmodule ExampleTest do
              Unifex.CNode.call(cnode, :test_list_of_strings, [['abc', 'def', 'ghi']])
   end
 
+  test "list of unsigned ints", context do
+    cnode = context[:cnode]
+    assert {:ok, [0, 1, 2]} = Unifex.CNode.call(cnode, :test_list_of_uints, [[0, 1, 2]])
+  end
+
   test "payload", context do
     assert {:ok, <<2, 2, 3>>} = Unifex.CNode.call(context[:cnode], :test_payload, [<<1, 2, 3>>])
   end

--- a/test_projects/nif/c_src/example/example.c
+++ b/test_projects/nif/c_src/example/example.c
@@ -17,13 +17,32 @@ UNIFEX_TERM init(UnifexEnv *env) {
   return res;
 }
 
-UNIFEX_TERM foo(UnifexEnv *env, UnifexPid pid, int *list,
-                unsigned int list_length, MyState *state) {
-  int res = send_example_msg(env, pid, 0, state->a);
+UNIFEX_TERM test_atom(UnifexEnv *env, char *in_atom) {
+  return test_atom_result_ok(env, in_atom);
+}
+
+UNIFEX_TERM test_int(UnifexEnv *env, int in_int) {
+  return test_int_result_ok(env, in_int);
+}
+
+UNIFEX_TERM test_list(UnifexEnv *env, int* in_list, unsigned int list_length) {
+  return test_list_result_ok(env, in_list, list_length);
+}
+
+UNIFEX_TERM test_pid(UnifexEnv *env, UnifexPid in_pid) {
+  return test_pid_result_ok(env, in_pid);
+}
+
+UNIFEX_TERM test_state(UnifexEnv *env, MyState *state) {
+  return test_state_result_ok(env, state);
+}
+
+UNIFEX_TERM test_example_message(UnifexEnv *env, UnifexPid pid) {
+  int res = send_example_msg(env, pid, 0, 10);
   if (!res) {
-    return foo_result_error(env, "send_failed");
+    return test_example_message_result_error(env, "send_failed");
   }
-  return foo_result_ok(env, list, list_length, state->a);
+  return test_example_message_result_ok(env);
 }
 
 void handle_destroy_state(UnifexEnv *env, MyState *state) {

--- a/test_projects/nif/c_src/example/example.spec.exs
+++ b/test_projects/nif/c_src/example/example.spec.exs
@@ -8,7 +8,16 @@ state_type "MyState"
 
 spec init() :: {:ok :: label, was_handle_load_called :: int, state}
 
-spec foo(target :: pid, list_in :: [int], state) ::
-       {:ok :: label, list_out :: [int], answer :: int} | {:error :: label, reason :: atom}
+spec test_atom(in_atom :: atom) :: {:ok :: label, out_atom :: atom}
+
+spec test_int(in_int :: int) :: {:ok :: label, out_int :: int}
+
+spec test_list(in_list :: [int]) :: {:ok :: label, out_list :: [int]}
+
+spec test_pid(in_pid :: pid) :: {:ok :: label, out_pid :: pid}
+
+spec test_state(state) :: {:ok :: label, state}
+
+spec test_example_message(pid :: pid) :: {:ok :: label} | {:error :: label, reason :: atom}
 
 sends {:example_msg :: label, num :: int}

--- a/test_projects/nif/test/example_test.exs
+++ b/test_projects/nif/test/example_test.exs
@@ -1,15 +1,37 @@
 defmodule ExampleTest do
   use ExUnit.Case
 
-  test "init" do
+  setup_all do
     assert {:ok, was_handle_load_called, state} = Example.init()
     assert was_handle_load_called == 1
     assert is_reference(state)
+    [state: state]
   end
 
-  test "foo" do
-    {:ok, _, state} = Example.init()
-    assert {:ok, [1, 2, 3], 42} = Example.foo(self(), [1, 2, 3], state)
-    assert_receive {:example_msg, 42}
+  test "atom" do
+    assert {:ok, :unifex} = Example.test_atom(:unifex)
+  end
+
+  test "int" do
+    assert {:ok, 10} = Example.test_int(10)
+  end
+
+  test "list" do
+    assert {:ok, [1, 2, 3]} = Example.test_list([1, 2, 3])
+  end
+
+  test "pid" do
+    pid = self()
+    assert {:ok, ^pid} = Example.test_pid(pid)
+  end
+
+  test "state", context do
+    state = context[:state]
+    assert {:ok, ^state} = Example.test_state(state)
+  end
+
+  test "example message" do
+    assert {:ok} = Example.test_example_message(self())
+    assert_receive {:example_msg, 10}
   end
 end


### PR DESCRIPTION
related with membraneframework/membrane_ice_plugin#2
related with #42

In this PR following types will be implemented for CNodes:
* string
* unsigned int 
* lists