### PR TITLE
Replace charlists with true strings in CNodes

### DIFF
--- a/lib/unifex/code_generator/base_types/string.ex
+++ b/lib/unifex/code_generator/base_types/string.ex
@@ -47,15 +47,22 @@ defmodule Unifex.CodeGenerator.BaseTypes.String do
     alias Unifex.CodeGenerator.BaseType
 
     @impl BaseType
+    def generate_arg_serialize(name, _ctx) do
+      ~g<ei_x_encode_binary(out_buff, #{name}, strlen(#{name}));>
+    end
+
+    @impl BaseType
     def generate_arg_parse(arg, var_name, _ctx) do
       ~g"""
       ({
         int type;
         int size;
+        long len;
         ei_get_type(#{arg}->buff, #{arg}->index, &type, &size);
         size = size + 1; // for NULL byte
         #{var_name} = malloc(sizeof(char) * size);
-        ei_decode_string(#{arg}->buff, #{arg}->index, #{var_name});
+        memset(#{var_name}, 0, size);
+        ei_decode_binary(#{arg}->buff, #{arg}->index, #{var_name}, &len);
       })
       """
     end

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -70,7 +70,7 @@ UNIFEX_TERM test_string_result_ok(UnifexEnv *env, const char *out_string) {
 
   ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "ok");
-  ei_x_encode_string(out_buff, out_string);
+  ei_x_encode_binary(out_buff, out_string, strlen(out_string));
 
   return out_buff;
 }
@@ -107,7 +107,7 @@ UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env,
   ({
     ei_x_encode_list_header(out_buff, out_strings_length);
     for (unsigned int i = 0; i < out_strings_length; i++) {
-      ei_x_encode_string(out_buff, out_strings[i]);
+      ei_x_encode_binary(out_buff, out_strings[i], strlen(out_strings[i]));
     }
     ei_x_encode_empty_list(out_buff);
   });
@@ -303,10 +303,12 @@ UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   if (({
         int type;
         int size;
+        long len;
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         size = size + 1; // for NULL byte
         in_string = malloc(sizeof(char) * size);
-        ei_decode_string(in_buff->buff, in_buff->index, in_string);
+        memset(in_string, 0, size);
+        ei_decode_binary(in_buff->buff, in_buff->index, in_string, &len);
       })) {
     result = unifex_raise(
         env,
@@ -429,12 +431,14 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
           if (({
                 int type;
                 int size;
+                long len;
                 ei_get_type(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                             &type, &size);
                 size = size + 1; // for NULL byte
                 in_strings[i] = malloc(sizeof(char) * size);
-                ei_decode_string(unifex_buff_ptr->buff, unifex_buff_ptr->index,
-                                 in_strings[i]);
+                memset(in_strings[i], 0, size);
+                ei_decode_binary(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                                 in_strings[i], &len);
               })) {
             result =
                 unifex_raise(env, "Unifex CNode: cannot parse argument "

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -70,7 +70,7 @@ UNIFEX_TERM test_string_result_ok(UnifexEnv *env, const char *out_string) {
 
   ei_x_encode_tuple_header(out_buff, 2);
   ei_x_encode_atom(out_buff, "ok");
-  ei_x_encode_string(out_buff, out_string);
+  ei_x_encode_binary(out_buff, out_string, strlen(out_string));
 
   return out_buff;
 }
@@ -107,7 +107,7 @@ UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env,
   ({
     ei_x_encode_list_header(out_buff, out_strings_length);
     for (unsigned int i = 0; i < out_strings_length; i++) {
-      ei_x_encode_string(out_buff, out_strings[i]);
+      ei_x_encode_binary(out_buff, out_strings[i], strlen(out_strings[i]));
     }
     ei_x_encode_empty_list(out_buff);
   });
@@ -303,10 +303,12 @@ UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   if (({
         int type;
         int size;
+        long len;
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         size = size + 1; // for NULL byte
         in_string = malloc(sizeof(char) * size);
-        ei_decode_string(in_buff->buff, in_buff->index, in_string);
+        memset(in_string, 0, size);
+        ei_decode_binary(in_buff->buff, in_buff->index, in_string, &len);
       })) {
     result = unifex_raise(
         env,
@@ -429,12 +431,14 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
           if (({
                 int type;
                 int size;
+                long len;
                 ei_get_type(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                             &type, &size);
                 size = size + 1; // for NULL byte
                 in_strings[i] = malloc(sizeof(char) * size);
-                ei_decode_string(unifex_buff_ptr->buff, unifex_buff_ptr->index,
-                                 in_strings[i]);
+                memset(in_strings[i], 0, size);
+                ei_decode_binary(unifex_buff_ptr->buff, unifex_buff_ptr->index,
+                                 in_strings[i], &len);
               })) {
             result =
                 unifex_raise(env, "Unifex CNode: cannot parse argument "

--- a/test_projects/cnode/test/example_test.exs
+++ b/test_projects/cnode/test/example_test.exs
@@ -32,14 +32,14 @@ defmodule ExampleTest do
     cnode = context[:cnode]
 
     big_test_string =
-      'unifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexu
+      "unifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexu
       nifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexuni
-      fexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifex'
+      fexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifexunifex"
 
-    assert {:ok, ''} = Unifex.CNode.call(cnode, :test_string, [''])
-    assert {:ok, 'test_string'} = Unifex.CNode.call(cnode, :test_string, ['test_string'])
-    assert {:ok, '-12345'} = Unifex.CNode.call(cnode, :test_string, ['-12345'])
-    assert {:ok, '255'} = Unifex.CNode.call(cnode, :test_string, ['255'])
+    assert {:ok, ""} = Unifex.CNode.call(cnode, :test_string, [""])
+    assert {:ok, "test_string"} = Unifex.CNode.call(cnode, :test_string, ["test_string"])
+    assert {:ok, "-12345"} = Unifex.CNode.call(cnode, :test_string, ["-12345"])
+    assert {:ok, "255"} = Unifex.CNode.call(cnode, :test_string, ["255"])
     assert {:ok, big_test_string} = Unifex.CNode.call(cnode, :test_string, [big_test_string])
   end
 
@@ -64,13 +64,13 @@ defmodule ExampleTest do
     cnode = context[:cnode]
     assert {:ok, []} = Unifex.CNode.call(cnode, :test_list_of_strings, [[]])
 
-    assert {:ok, ['', '', '']} = Unifex.CNode.call(cnode, :test_list_of_strings, [['', '', '']])
+    assert {:ok, ["", "", ""]} = Unifex.CNode.call(cnode, :test_list_of_strings, [["", "", ""]])
 
-    assert {:ok, ['1', '2', '3']} =
-             Unifex.CNode.call(cnode, :test_list_of_strings, [['1', '2', '3']])
+    assert {:ok, ["1", "2", "3"]} =
+             Unifex.CNode.call(cnode, :test_list_of_strings, [["1", "2", "3"]])
 
-    assert {:ok, ['abc', 'def', 'ghi']} =
-             Unifex.CNode.call(cnode, :test_list_of_strings, [['abc', 'def', 'ghi']])
+    assert {:ok, ["abc", "def", "ghi"]} =
+             Unifex.CNode.call(cnode, :test_list_of_strings, [["abc", "def", "ghi"]])
   end
 
   test "list of unsigned ints", context do


### PR DESCRIPTION
This PR fixes String implementation for CNodes. The first one version was implemented using `ei_decode_string` and `ei_x_encode_string` which supports only charlists. These functions has been replaced with `ei_decode_binary` and `ei_x_encode_binary` which supports `Strings`. 