### PR TITLE
Cast pointers returned from malloc

### DIFF
--- a/lib/unifex/code_generator/base_types/list.ex
+++ b/lib/unifex/code_generator/base_types/list.ex
@@ -135,7 +135,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
         }
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index, &size);
         #{len_var_name} = (unsigned int) size;
-        #{var_name} = malloc(sizeof(#{native_type}) * #{len_var_name});
+        #{var_name} = (#{native_type} *)malloc(sizeof(#{native_type}) * #{len_var_name});
 
         for(unsigned int i = 0; i < #{len_var_name}; i++) {
           #{BaseType.generate_initialization(subtype, elem_name, generator)}

--- a/lib/unifex/code_generator/base_types/string.ex
+++ b/lib/unifex/code_generator/base_types/string.ex
@@ -60,7 +60,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.String do
         long len;
         ei_get_type(#{arg}->buff, #{arg}->index, &type, &size);
         size = size + 1; // for NULL byte
-        #{var_name} = malloc(sizeof(char) * size);
+        #{var_name} = (char *)malloc(sizeof(char) * size);
         memset(#{var_name}, 0, size);
         ei_decode_binary(#{arg}->buff, #{arg}->index, #{var_name}, &len);
       })

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -306,7 +306,7 @@ UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         long len;
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         size = size + 1; // for NULL byte
-        in_string = malloc(sizeof(char) * size);
+        in_string = (char *)malloc(sizeof(char) * size);
         memset(in_string, 0, size);
         ei_decode_binary(in_buff->buff, in_buff->index, in_string, &len);
       })) {
@@ -350,7 +350,7 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
-        in_list = malloc(sizeof(int) * in_list_length);
+        in_list = (int *)malloc(sizeof(int) * in_list_length);
 
         for (unsigned int i = 0; i < in_list_length; i++) {
         }
@@ -421,7 +421,7 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_strings_length = (unsigned int)size;
-        in_strings = malloc(sizeof(char *) * in_strings_length);
+        in_strings = (char **)malloc(sizeof(char *) * in_strings_length);
 
         for (unsigned int i = 0; i < in_strings_length; i++) {
           in_strings[i] = NULL;
@@ -435,7 +435,7 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
                 ei_get_type(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                             &type, &size);
                 size = size + 1; // for NULL byte
-                in_strings[i] = malloc(sizeof(char) * size);
+                in_strings[i] = (char *)malloc(sizeof(char) * size);
                 memset(in_strings[i], 0, size);
                 ei_decode_binary(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                                  in_strings[i], &len);
@@ -499,7 +499,8 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_uints_length = (unsigned int)size;
-        in_uints = malloc(sizeof(unsigned int) * in_uints_length);
+        in_uints =
+            (unsigned int *)malloc(sizeof(unsigned int) * in_uints_length);
 
         for (unsigned int i = 0; i < in_uints_length; i++) {
         }
@@ -572,7 +573,7 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
-        in_list = malloc(sizeof(int) * in_list_length);
+        in_list = (int *)malloc(sizeof(int) * in_list_length);
 
         for (unsigned int i = 0; i < in_list_length; i++) {
         }

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -306,7 +306,7 @@ UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         long len;
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         size = size + 1; // for NULL byte
-        in_string = malloc(sizeof(char) * size);
+        in_string = (char *)malloc(sizeof(char) * size);
         memset(in_string, 0, size);
         ei_decode_binary(in_buff->buff, in_buff->index, in_string, &len);
       })) {
@@ -350,7 +350,7 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
-        in_list = malloc(sizeof(int) * in_list_length);
+        in_list = (int *)malloc(sizeof(int) * in_list_length);
 
         for (unsigned int i = 0; i < in_list_length; i++) {
         }
@@ -421,7 +421,7 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_strings_length = (unsigned int)size;
-        in_strings = malloc(sizeof(char *) * in_strings_length);
+        in_strings = (char **)malloc(sizeof(char *) * in_strings_length);
 
         for (unsigned int i = 0; i < in_strings_length; i++) {
           in_strings[i] = NULL;
@@ -435,7 +435,7 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
                 ei_get_type(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                             &type, &size);
                 size = size + 1; // for NULL byte
-                in_strings[i] = malloc(sizeof(char) * size);
+                in_strings[i] = (char *)malloc(sizeof(char) * size);
                 memset(in_strings[i], 0, size);
                 ei_decode_binary(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                                  in_strings[i], &len);
@@ -499,7 +499,8 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_uints_length = (unsigned int)size;
-        in_uints = malloc(sizeof(unsigned int) * in_uints_length);
+        in_uints =
+            (unsigned int *)malloc(sizeof(unsigned int) * in_uints_length);
 
         for (unsigned int i = 0; i < in_uints_length; i++) {
         }
@@ -572,7 +573,7 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
-        in_list = malloc(sizeof(int) * in_list_length);
+        in_list = (int *)malloc(sizeof(int) * in_list_length);
 
         for (unsigned int i = 0; i < in_list_length; i++) {
         }


### PR DESCRIPTION
Fix bug described [here](https://github.com/membraneframework/unifex/issues/62#issuecomment-694129554).