### PR TITLE
Add support for floats

### DIFF
--- a/lib/unifex/code_generator/base_types/float.ex
+++ b/lib/unifex/code_generator/base_types/float.ex
@@ -1,0 +1,46 @@
+defmodule Unifex.CodeGenerator.BaseTypes.Float do
+  @moduledoc """
+  Module implementing `Unifex.CodeGenerator.BaseType` behaviour for floats.
+
+  Implemented both for NIF and CNode as function parameter as well as return type.
+  """
+  alias Unifex.CodeGenerator.BaseType
+  use BaseType
+
+  @impl BaseType
+  def generate_native_type(_ctx) do
+    ~g<double>
+  end
+
+  defmodule NIF do
+    @moduledoc false
+    alias Unifex.CodeGenerator.BaseType
+    use BaseType
+
+    @impl BaseType
+    def generate_arg_serialize(name, _ctx) do
+      ~g<enif_make_double(env, #{name})>
+    end
+
+    @impl BaseType
+    def generate_arg_parse(argument, variable, _ctx) do
+      ~g<enif_get_double(env, #{argument}, &#{variable})>
+    end
+  end
+
+  defmodule CNode do
+    @moduledoc false
+    alias Unifex.CodeGenerator.BaseType
+    use BaseType
+
+    @impl BaseType
+    def generate_arg_parse(argument, name, _ctx) do
+      ~g<ei_decode_double(#{argument}-\>buff, #{argument}-\>index, &#{name})>
+    end
+
+    @impl BaseType
+    def generate_arg_serialize(name, _ctx) do
+      ~g<ei_x_encode_double(out_buff, #{name});>
+    end
+  end
+end

--- a/lib/unifex/code_generator/base_types/list.ex
+++ b/lib/unifex/code_generator/base_types/list.ex
@@ -135,7 +135,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
         }
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff, unifex_buff_ptr->index, &size);
         #{len_var_name} = (unsigned int) size;
-        #{var_name} = malloc(sizeof(#{native_type}) * #{len_var_name});
+        #{var_name} = (#{native_type} *)malloc(sizeof(#{native_type}) * #{len_var_name});
 
         for(unsigned int i = 0; i < #{len_var_name}; i++) {
           #{BaseType.generate_initialization(subtype, elem_name, generator)}

--- a/lib/unifex/code_generator/base_types/string.ex
+++ b/lib/unifex/code_generator/base_types/string.ex
@@ -60,7 +60,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.String do
         long len;
         ei_get_type(#{arg}->buff, #{arg}->index, &type, &size);
         size = size + 1; // for NULL byte
-        #{var_name} = malloc(sizeof(char) * size);
+        #{var_name} = (char *)malloc(sizeof(char) * size);
         memset(#{var_name}, 0, size);
         ei_decode_binary(#{arg}->buff, #{arg}->index, #{var_name}, &len);
       })

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -50,6 +50,17 @@ UNIFEX_TERM test_bool_result_ok(UnifexEnv *env, int out_bool) {
   return out_buff;
 }
 
+UNIFEX_TERM test_float_result_ok(UnifexEnv *env, double out_float) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 2);
+  ei_x_encode_atom(out_buff, "ok");
+  ei_x_encode_double(out_buff, out_float);
+
+  return out_buff;
+}
+
 UNIFEX_TERM test_uint_result_ok(UnifexEnv *env, unsigned int out_uint) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
@@ -266,6 +277,24 @@ UNIFEX_TERM test_bool_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   result = test_bool(env, in_bool);
   goto exit_test_bool_caller;
 exit_test_bool_caller:
+
+  return result;
+}
+
+UNIFEX_TERM test_float_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  double in_float;
+
+  if (ei_decode_double(in_buff->buff, in_buff->index, &in_float)) {
+    result = unifex_raise(
+        env, "Unifex CNode: cannot parse argument 'in_float' of type ':float'");
+    goto exit_test_float_caller;
+  }
+
+  result = test_float(env, in_float);
+  goto exit_test_float_caller;
+exit_test_float_caller:
 
   return result;
 }
@@ -703,6 +732,8 @@ UNIFEX_TERM unifex_cnode_handle_message(UnifexEnv *env, char *fun_name,
     return test_atom_caller(env, in_buff);
   } else if (strcmp(fun_name, "test_bool") == 0) {
     return test_bool_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_float") == 0) {
+    return test_float_caller(env, in_buff);
   } else if (strcmp(fun_name, "test_uint") == 0) {
     return test_uint_caller(env, in_buff);
   } else if (strcmp(fun_name, "test_string") == 0) {

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -306,7 +306,7 @@ UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         long len;
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         size = size + 1; // for NULL byte
-        in_string = malloc(sizeof(char) * size);
+        in_string = (char *)malloc(sizeof(char) * size);
         memset(in_string, 0, size);
         ei_decode_binary(in_buff->buff, in_buff->index, in_string, &len);
       })) {
@@ -350,7 +350,7 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
-        in_list = malloc(sizeof(int) * in_list_length);
+        in_list = (int *)malloc(sizeof(int) * in_list_length);
 
         for (unsigned int i = 0; i < in_list_length; i++) {
         }
@@ -421,7 +421,7 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_strings_length = (unsigned int)size;
-        in_strings = malloc(sizeof(char *) * in_strings_length);
+        in_strings = (char **)malloc(sizeof(char *) * in_strings_length);
 
         for (unsigned int i = 0; i < in_strings_length; i++) {
           in_strings[i] = NULL;
@@ -435,7 +435,7 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
                 ei_get_type(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                             &type, &size);
                 size = size + 1; // for NULL byte
-                in_strings[i] = malloc(sizeof(char) * size);
+                in_strings[i] = (char *)malloc(sizeof(char) * size);
                 memset(in_strings[i], 0, size);
                 ei_decode_binary(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                                  in_strings[i], &len);
@@ -499,7 +499,8 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_uints_length = (unsigned int)size;
-        in_uints = malloc(sizeof(unsigned int) * in_uints_length);
+        in_uints =
+            (unsigned int *)malloc(sizeof(unsigned int) * in_uints_length);
 
         for (unsigned int i = 0; i < in_uints_length; i++) {
         }
@@ -572,7 +573,7 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
-        in_list = malloc(sizeof(int) * in_list_length);
+        in_list = (int *)malloc(sizeof(int) * in_list_length);
 
         for (unsigned int i = 0; i < in_list_length; i++) {
         }

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -50,6 +50,17 @@ UNIFEX_TERM test_bool_result_ok(UnifexEnv *env, int out_bool) {
   return out_buff;
 }
 
+UNIFEX_TERM test_float_result_ok(UnifexEnv *env, double out_float) {
+  UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
+  unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
+
+  ei_x_encode_tuple_header(out_buff, 2);
+  ei_x_encode_atom(out_buff, "ok");
+  ei_x_encode_double(out_buff, out_float);
+
+  return out_buff;
+}
+
 UNIFEX_TERM test_uint_result_ok(UnifexEnv *env, unsigned int out_uint) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
@@ -266,6 +277,24 @@ UNIFEX_TERM test_bool_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
   result = test_bool(env, in_bool);
   goto exit_test_bool_caller;
 exit_test_bool_caller:
+
+  return result;
+}
+
+UNIFEX_TERM test_float_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_TERM result;
+
+  double in_float;
+
+  if (ei_decode_double(in_buff->buff, in_buff->index, &in_float)) {
+    result = unifex_raise(
+        env, "Unifex CNode: cannot parse argument 'in_float' of type ':float'");
+    goto exit_test_float_caller;
+  }
+
+  result = test_float(env, in_float);
+  goto exit_test_float_caller;
+exit_test_float_caller:
 
   return result;
 }
@@ -703,6 +732,8 @@ UNIFEX_TERM unifex_cnode_handle_message(UnifexEnv *env, char *fun_name,
     return test_atom_caller(env, in_buff);
   } else if (strcmp(fun_name, "test_bool") == 0) {
     return test_bool_caller(env, in_buff);
+  } else if (strcmp(fun_name, "test_float") == 0) {
+    return test_float_caller(env, in_buff);
   } else if (strcmp(fun_name, "test_uint") == 0) {
     return test_uint_caller(env, in_buff);
   } else if (strcmp(fun_name, "test_string") == 0) {

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -306,7 +306,7 @@ UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         long len;
         ei_get_type(in_buff->buff, in_buff->index, &type, &size);
         size = size + 1; // for NULL byte
-        in_string = malloc(sizeof(char) * size);
+        in_string = (char *)malloc(sizeof(char) * size);
         memset(in_string, 0, size);
         ei_decode_binary(in_buff->buff, in_buff->index, in_string, &len);
       })) {
@@ -350,7 +350,7 @@ UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
-        in_list = malloc(sizeof(int) * in_list_length);
+        in_list = (int *)malloc(sizeof(int) * in_list_length);
 
         for (unsigned int i = 0; i < in_list_length; i++) {
         }
@@ -421,7 +421,7 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_strings_length = (unsigned int)size;
-        in_strings = malloc(sizeof(char *) * in_strings_length);
+        in_strings = (char **)malloc(sizeof(char *) * in_strings_length);
 
         for (unsigned int i = 0; i < in_strings_length; i++) {
           in_strings[i] = NULL;
@@ -435,7 +435,7 @@ UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
                 ei_get_type(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                             &type, &size);
                 size = size + 1; // for NULL byte
-                in_strings[i] = malloc(sizeof(char) * size);
+                in_strings[i] = (char *)malloc(sizeof(char) * size);
                 memset(in_strings[i], 0, size);
                 ei_decode_binary(unifex_buff_ptr->buff, unifex_buff_ptr->index,
                                  in_strings[i], &len);
@@ -499,7 +499,8 @@ UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_uints_length = (unsigned int)size;
-        in_uints = malloc(sizeof(unsigned int) * in_uints_length);
+        in_uints =
+            (unsigned int *)malloc(sizeof(unsigned int) * in_uints_length);
 
         for (unsigned int i = 0; i < in_uints_length; i++) {
         }
@@ -572,7 +573,7 @@ UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
         int header_res = ei_decode_list_header(unifex_buff_ptr->buff,
                                                unifex_buff_ptr->index, &size);
         in_list_length = (unsigned int)size;
-        in_list = malloc(sizeof(int) * in_list_length);
+        in_list = (int *)malloc(sizeof(int) * in_list_length);
 
         for (unsigned int i = 0; i < in_list_length; i++) {
         }

--- a/test/fixtures/cnode_ref_generated/cnode/example.h
+++ b/test/fixtures/cnode_ref_generated/cnode/example.h
@@ -31,6 +31,7 @@ void handle_destroy_state(UnifexEnv *env, UnifexState *state);
 UNIFEX_TERM init(UnifexEnv *env);
 UNIFEX_TERM test_atom(UnifexEnv *env, char *in_atom);
 UNIFEX_TERM test_bool(UnifexEnv *env, int in_bool);
+UNIFEX_TERM test_float(UnifexEnv *env, double in_float);
 UNIFEX_TERM test_uint(UnifexEnv *env, unsigned int in_uint);
 UNIFEX_TERM test_string(UnifexEnv *env, char *in_string);
 UNIFEX_TERM test_list(UnifexEnv *env, int *in_list,
@@ -48,6 +49,7 @@ UNIFEX_TERM test_example_message(UnifexEnv *env);
 UNIFEX_TERM init_result_ok(UnifexEnv *env, UnifexState *state);
 UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom);
 UNIFEX_TERM test_bool_result_ok(UnifexEnv *env, int out_bool);
+UNIFEX_TERM test_float_result_ok(UnifexEnv *env, double out_float);
 UNIFEX_TERM test_uint_result_ok(UnifexEnv *env, unsigned int out_uint);
 UNIFEX_TERM test_string_result_ok(UnifexEnv *env, const char *out_string);
 UNIFEX_TERM test_list_result_ok(UnifexEnv *env, const int *out_list,
@@ -70,6 +72,7 @@ UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
 UNIFEX_TERM init_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_atom_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_bool_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
+UNIFEX_TERM test_float_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_uint_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);
 UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff);

--- a/test/fixtures/nif_ref_generated/nif/example.c
+++ b/test/fixtures/nif_ref_generated/nif/example.c
@@ -18,6 +18,14 @@ UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom) {
   });
 }
 
+UNIFEX_TERM test_float_result_ok(UnifexEnv *env, double out_float) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
+                                  enif_make_double(env, out_float)};
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
 UNIFEX_TERM test_int_result_ok(UnifexEnv *env, int out_int) {
   return ({
     const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
@@ -165,6 +173,26 @@ exit_export_test_atom:
   return result;
 }
 
+static ERL_NIF_TERM export_test_float(ErlNifEnv *env, int argc,
+                                      const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  double in_float;
+
+  if (!enif_get_double(env, argv[0], &in_float)) {
+    result = unifex_raise_args_error(env, "in_float", ":float");
+    goto exit_export_test_float;
+  }
+
+  result = test_float(unifex_env, in_float);
+  goto exit_export_test_float;
+exit_export_test_float:
+
+  return result;
+}
+
 static ERL_NIF_TERM export_test_int(ErlNifEnv *env, int argc,
                                     const ERL_NIF_TERM argv[]) {
   UNIFEX_UNUSED(argc);
@@ -296,6 +324,7 @@ exit_export_test_example_message:
 static ErlNifFunc nif_funcs[] = {
     {"unifex_init", 0, export_init, 0},
     {"unifex_test_atom", 1, export_test_atom, 0},
+    {"unifex_test_float", 1, export_test_float, 0},
     {"unifex_test_int", 1, export_test_int, 0},
     {"unifex_test_list", 1, export_test_list, 0},
     {"unifex_test_pid", 1, export_test_pid, 0},

--- a/test/fixtures/nif_ref_generated/nif/example.cpp
+++ b/test/fixtures/nif_ref_generated/nif/example.cpp
@@ -18,6 +18,14 @@ UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom) {
   });
 }
 
+UNIFEX_TERM test_float_result_ok(UnifexEnv *env, double out_float) {
+  return ({
+    const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
+                                  enif_make_double(env, out_float)};
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
 UNIFEX_TERM test_int_result_ok(UnifexEnv *env, int out_int) {
   return ({
     const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
@@ -165,6 +173,26 @@ exit_export_test_atom:
   return result;
 }
 
+static ERL_NIF_TERM export_test_float(ErlNifEnv *env, int argc,
+                                      const ERL_NIF_TERM argv[]) {
+  UNIFEX_UNUSED(argc);
+  ERL_NIF_TERM result;
+
+  UnifexEnv *unifex_env = env;
+  double in_float;
+
+  if (!enif_get_double(env, argv[0], &in_float)) {
+    result = unifex_raise_args_error(env, "in_float", ":float");
+    goto exit_export_test_float;
+  }
+
+  result = test_float(unifex_env, in_float);
+  goto exit_export_test_float;
+exit_export_test_float:
+
+  return result;
+}
+
 static ERL_NIF_TERM export_test_int(ErlNifEnv *env, int argc,
                                     const ERL_NIF_TERM argv[]) {
   UNIFEX_UNUSED(argc);
@@ -296,6 +324,7 @@ exit_export_test_example_message:
 static ErlNifFunc nif_funcs[] = {
     {"unifex_init", 0, export_init, 0},
     {"unifex_test_atom", 1, export_test_atom, 0},
+    {"unifex_test_float", 1, export_test_float, 0},
     {"unifex_test_int", 1, export_test_int, 0},
     {"unifex_test_list", 1, export_test_list, 0},
     {"unifex_test_pid", 1, export_test_pid, 0},

--- a/test/fixtures/nif_ref_generated/nif/example.h
+++ b/test/fixtures/nif_ref_generated/nif/example.h
@@ -54,6 +54,7 @@ void handle_destroy_state(UnifexEnv *env, UnifexState *state);
 
 UNIFEX_TERM init(UnifexEnv *env);
 UNIFEX_TERM test_atom(UnifexEnv *env, char *in_atom);
+UNIFEX_TERM test_float(UnifexEnv *env, double in_float);
 UNIFEX_TERM test_int(UnifexEnv *env, int in_int);
 UNIFEX_TERM test_list(UnifexEnv *env, int *in_list,
                       unsigned int in_list_length);
@@ -76,6 +77,7 @@ int handle_load(UnifexEnv *env, void **priv_data);
 UNIFEX_TERM init_result_ok(UnifexEnv *env, int was_handle_load_called,
                            UnifexState *state);
 UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom);
+UNIFEX_TERM test_float_result_ok(UnifexEnv *env, double out_float);
 UNIFEX_TERM test_int_result_ok(UnifexEnv *env, int out_int);
 UNIFEX_TERM test_list_result_ok(UnifexEnv *env, const int *out_list,
                                 unsigned int out_list_length);

--- a/test_projects/cnode/c_src/example/example.c
+++ b/test_projects/cnode/c_src/example/example.c
@@ -16,6 +16,10 @@ UNIFEX_TERM test_bool(UnifexEnv *env, int in_bool) {
   return test_bool_result_ok(env, in_bool);
 }
 
+UNIFEX_TERM test_float(UnifexEnv *env, double in_float) {
+  return test_float_result_ok(env, in_float);
+}
+
 UNIFEX_TERM test_uint(UnifexEnv *env, unsigned int in_uint) {
   return test_uint_result_ok(env, in_uint);
 }

--- a/test_projects/cnode/c_src/example/example.spec.exs
+++ b/test_projects/cnode/c_src/example/example.spec.exs
@@ -12,6 +12,8 @@ spec test_atom(in_atom :: atom) :: {:ok :: label, out_atom :: atom}
 
 spec test_bool(in_bool :: bool) :: {:ok :: label, out_bool :: bool}
 
+spec test_float(in_float :: float) :: {:ok :: label, out_float :: float}
+
 spec test_uint(in_uint :: unsigned) :: {:ok :: label, out_uint :: unsigned}
 
 spec test_string(in_string :: string) :: {:ok :: label, out_string :: string}

--- a/test_projects/cnode/test/example_test.exs
+++ b/test_projects/cnode/test/example_test.exs
@@ -18,6 +18,13 @@ defmodule ExampleTest do
     refute match?({:ok, false}, Unifex.CNode.call(context[:cnode], :test_bool, [true]))
   end
 
+  test "float", context do
+    assert {:ok, 0.0} = Unifex.CNode.call(context[:cnode], :test_float, [0.0])
+    assert {:ok, 0.1} = Unifex.CNode.call(context[:cnode], :test_float, [0.1])
+    assert {:ok, -0.1} = Unifex.CNode.call(context[:cnode], :test_float, [-0.1])
+    refute match?({:ok, 1}, Unifex.CNode.call(context[:cnode], :test_float, [1.0]))
+  end
+
   test "unsigned int", context do
     cnode = context[:cnode]
     assert {:ok, 0} = Unifex.CNode.call(cnode, :test_uint, [0])

--- a/test_projects/nif/c_src/example/example.c
+++ b/test_projects/nif/c_src/example/example.c
@@ -21,6 +21,10 @@ UNIFEX_TERM test_atom(UnifexEnv *env, char *in_atom) {
   return test_atom_result_ok(env, in_atom);
 }
 
+UNIFEX_TERM test_float(UnifexEnv *env, double in_float) {
+  return test_float_result_ok(env, in_float);
+}
+
 UNIFEX_TERM test_int(UnifexEnv *env, int in_int) {
   return test_int_result_ok(env, in_int);
 }

--- a/test_projects/nif/c_src/example/example.spec.exs
+++ b/test_projects/nif/c_src/example/example.spec.exs
@@ -10,6 +10,8 @@ spec init() :: {:ok :: label, was_handle_load_called :: int, state}
 
 spec test_atom(in_atom :: atom) :: {:ok :: label, out_atom :: atom}
 
+spec test_float(in_float :: float) :: {:ok :: label, out_float :: float}
+
 spec test_int(in_int :: int) :: {:ok :: label, out_int :: int}
 
 spec test_list(in_list :: [int]) :: {:ok :: label, out_list :: [int]}

--- a/test_projects/nif/test/example_test.exs
+++ b/test_projects/nif/test/example_test.exs
@@ -12,6 +12,13 @@ defmodule ExampleTest do
     assert {:ok, :unifex} = Example.test_atom(:unifex)
   end
 
+  test "float" do
+    assert {:ok, 0.0} = Example.test_float(0.0)
+    assert {:ok, 0.1} = Example.test_float(0.1)
+    assert {:ok, -0.1} = Example.test_float(-0.1)
+    refute match?({:ok, 1}, Example.test_float(1.0))
+  end
+
   test "int" do
     assert {:ok, 10} = Example.test_int(10)
   end


### PR DESCRIPTION
Implement float both for NIF and CNode as function parameter as well as return type. 

Related with #62 