### PR TITLE
Fix warning with unused parameter in generated code

### DIFF
--- a/c_src/unifex/cnode/unifex/unifex.h
+++ b/c_src/unifex/cnode/unifex/unifex.h
@@ -21,6 +21,8 @@ typedef ei_x_buff *UNIFEX_TERM;
 
 typedef erlang_pid UnifexPid;
 
+#define UNIFEX_MAYBE_UNUSED(x) UNIFEX_UNUSED(x)
+
 #define UNIFEX_UNUSED(x) (void)(x)
 
 typedef struct UnifexLinkedList {

--- a/c_src/unifex/nif/unifex/unifex.h
+++ b/c_src/unifex/nif/unifex/unifex.h
@@ -7,6 +7,8 @@
 
 #define UNIFEX_UNUSED(x) (void)(x)
 
+#define UNIFEX_MAYBE_UNUSED(x) UNIFEX_UNUSED(x)
+
 #define UNIFEX_NO_FLAGS 0
 
 #define UNIFEX_SEND_THREADED 1

--- a/lib/unifex/code_generator/utils.ex
+++ b/lib/unifex/code_generator/utils.ex
@@ -96,4 +96,9 @@ defmodule Unifex.CodeGenerator.Utils do
     |> Enum.map(&(&1 <> ";"))
     |> Enum.join("\n")
   end
+
+  @spec generate_maybe_unused_args_statements(args :: [String.t()]) :: [String.t()]
+  def generate_maybe_unused_args_statements(args) do
+    args |> Enum.map(fn arg -> ~g<UNIFEX_MAYBE_UNUSED(#{arg});> end)
+  end
 end

--- a/lib/unifex/code_generators/cnode.ex
+++ b/lib/unifex/code_generators/cnode.ex
@@ -215,7 +215,7 @@ defmodule Unifex.CodeGenerators.CNode do
     declaration = generate_caller_function_declaration({name, args})
     exit_label = "exit_#{name}_caller"
 
-    maybe_unused_args = generate_maybe_unused_args_statements(["in_buff"]) |> Enum.join("\n")
+    maybe_unused_args = Utils.generate_maybe_unused_args_statements(["in_buff"])
 
     args_declaration =
       args |> generate_args_declarations() |> Enum.map(&~g<#{&1};>) |> Enum.join("\n")
@@ -275,10 +275,6 @@ defmodule Unifex.CodeGenerators.CNode do
     ~g"UNIFEX_TERM #{name}_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff)"
   end
 
-  defp generate_maybe_unused_args_statements(args) do
-    args |> Enum.map(fn arg -> ~g<UNIFEX_MAYBE_UNUSED(#{arg});> end)
-  end
-
   defp generate_state_related_declarations(%Specs{state_type: nil}) do
     ~g<>
   end
@@ -294,7 +290,8 @@ defmodule Unifex.CodeGenerators.CNode do
   end
 
   defp generate_state_related_functions(%Specs{state_type: nil}) do
-    maybe_unused_args = generate_maybe_unused_args_statements(["env", "state"]) |> Enum.join("\n")
+    maybe_unused_args =
+      Utils.generate_maybe_unused_args_statements(["env", "state"]) |> Enum.join("\n")
 
     ~g"""
     void unifex_cnode_destroy_state(UnifexEnv *env, void *state) {

--- a/lib/unifex/code_generators/nif.ex
+++ b/lib/unifex/code_generators/nif.ex
@@ -181,7 +181,8 @@ defmodule Unifex.CodeGenerators.NIF do
     result_var = "result"
     exit_label = "exit_export_#{name}"
 
-    maybe_unused_args = generate_maybe_unused_args_statements(["argc", "argv"]) |> Enum.join("\n")
+    maybe_unused_args =
+      Utils.generate_maybe_unused_args_statements(["argc", "argv"]) |> Enum.join("\n")
 
     args_declaration =
       args
@@ -238,10 +239,6 @@ defmodule Unifex.CodeGenerators.NIF do
       return result;
     }
     """
-  end
-
-  defp generate_maybe_unused_args_statements(args) do
-    args |> Enum.map(fn arg -> ~g<UNIFEX_MAYBE_UNUSED(#{arg});> end)
   end
 
   defp generate_state_related_declarations(%Specs{state_type: nil}) do

--- a/lib/unifex/code_generators/nif.ex
+++ b/lib/unifex/code_generators/nif.ex
@@ -181,6 +181,8 @@ defmodule Unifex.CodeGenerators.NIF do
     result_var = "result"
     exit_label = "exit_export_#{name}"
 
+    maybe_unused_args = generate_maybe_unused_args_statements(["argc", "argv"]) |> Enum.join("\n")
+
     args_declaration =
       args
       |> Enum.flat_map(fn {name, type} -> BaseType.generate_declaration(type, name, NIF) end)
@@ -220,9 +222,8 @@ defmodule Unifex.CodeGenerators.NIF do
 
     ~g"""
     static ERL_NIF_TERM export_#{name}(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]){
-      UNIFEX_UNUSED(argc);
+      #{maybe_unused_args}
       ERL_NIF_TERM #{result_var};
-      #{if args |> Enum.empty?(), do: ~g<UNIFEX_UNUSED(argv);>, else: ""}
       #{generate_unifex_env()}
       #{args_declaration}
 
@@ -237,6 +238,10 @@ defmodule Unifex.CodeGenerators.NIF do
       return result;
     }
     """
+  end
+
+  defp generate_maybe_unused_args_statements(args) do
+    args |> Enum.map(fn arg -> ~g<UNIFEX_MAYBE_UNUSED(#{arg});> end)
   end
 
   defp generate_state_related_declarations(%Specs{state_type: nil}) do

--- a/test/fixtures/bundlex_exs_ref_generated/cnode/example.c
+++ b/test/fixtures/bundlex_exs_ref_generated/cnode/example.c
@@ -1,7 +1,10 @@
 #include "example.h"
 #include <stdio.h>
 
-void unifex_cnode_destroy_state(UnifexEnv *env, void *state) {}
+void unifex_cnode_destroy_state(UnifexEnv *env, void *state) {
+  UNIFEX_MAYBE_UNUSED(env);
+  UNIFEX_MAYBE_UNUSED(state);
+}
 
 UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
@@ -18,8 +21,8 @@ UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
 }
 
 UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   int num;
 
   if (({

--- a/test/fixtures/bundlex_exs_ref_generated/cnode/example.cpp
+++ b/test/fixtures/bundlex_exs_ref_generated/cnode/example.cpp
@@ -1,7 +1,10 @@
 #include "example.h"
 #include <stdio.h>
 
-void unifex_cnode_destroy_state(UnifexEnv *env, void *state) {}
+void unifex_cnode_destroy_state(UnifexEnv *env, void *state) {
+  UNIFEX_MAYBE_UNUSED(env);
+  UNIFEX_MAYBE_UNUSED(state);
+}
 
 UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
@@ -18,8 +21,8 @@ UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
 }
 
 UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   int num;
 
   if (({

--- a/test/fixtures/bundlex_exs_ref_generated/nif/example.c
+++ b/test/fixtures/bundlex_exs_ref_generated/nif/example.c
@@ -25,9 +25,9 @@ static int unifex_load_nif(ErlNifEnv *env, void **priv_data,
 
 static ERL_NIF_TERM export_foo(ErlNifEnv *env, int argc,
                                const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   int num;
 

--- a/test/fixtures/bundlex_exs_ref_generated/nif/example.cpp
+++ b/test/fixtures/bundlex_exs_ref_generated/nif/example.cpp
@@ -25,9 +25,9 @@ static int unifex_load_nif(ErlNifEnv *env, void **priv_data,
 
 static ERL_NIF_TERM export_foo(ErlNifEnv *env, int argc,
                                const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   int num;
 

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -218,8 +218,8 @@ UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
 }
 
 UNIFEX_TERM init_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-  UNIFEX_UNUSED(in_buff);
 
   result = init(env);
   goto exit_init_caller;
@@ -229,8 +229,8 @@ exit_init_caller:
 }
 
 UNIFEX_TERM test_atom_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   char *in_atom;
   in_atom = NULL;
   if (({
@@ -251,8 +251,8 @@ exit_test_atom_caller:
 }
 
 UNIFEX_TERM test_bool_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   int in_bool;
 
   if (({
@@ -282,8 +282,8 @@ exit_test_bool_caller:
 }
 
 UNIFEX_TERM test_float_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   double in_float;
 
   if (ei_decode_double(in_buff->buff, in_buff->index, &in_float)) {
@@ -300,8 +300,8 @@ exit_test_float_caller:
 }
 
 UNIFEX_TERM test_uint_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   unsigned int in_uint;
 
   if (({
@@ -325,8 +325,8 @@ exit_test_uint_caller:
 }
 
 UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   char *in_string;
   in_string = NULL;
   if (({
@@ -353,8 +353,8 @@ exit_test_string_caller:
 }
 
 UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   int *in_list;
   unsigned int in_list_length;
   in_list = NULL;
@@ -423,8 +423,8 @@ exit_test_list_caller:
 
 UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
                                         UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   char **in_strings;
   unsigned int in_strings_length;
   in_strings = NULL;
@@ -501,8 +501,8 @@ exit_test_list_of_strings_caller:
 
 UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
                                       UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   unsigned int *in_uints;
   unsigned int in_uints_length;
   in_uints = NULL;
@@ -574,8 +574,8 @@ exit_test_list_of_uints_caller:
 
 UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
                                              UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   int *in_list;
   unsigned int in_list_length;
   char *other_param;
@@ -657,8 +657,8 @@ exit_test_list_with_other_args_caller:
 }
 
 UNIFEX_TERM test_payload_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   UnifexPayload *in_payload;
   in_payload = NULL;
   if (unifex_payload_decode(env, in_buff, &in_payload)) {
@@ -679,8 +679,8 @@ exit_test_payload_caller:
 }
 
 UNIFEX_TERM test_pid_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   UnifexPid in_pid;
 
   if (ei_decode_pid(in_buff->buff, in_buff->index, &in_pid)) {
@@ -698,8 +698,8 @@ exit_test_pid_caller:
 
 UNIFEX_TERM test_example_message_caller(UnifexEnv *env,
                                         UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-  UNIFEX_UNUSED(in_buff);
 
   result = test_example_message(env);
   goto exit_test_example_message_caller;

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -218,8 +218,8 @@ UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
 }
 
 UNIFEX_TERM init_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-  UNIFEX_UNUSED(in_buff);
 
   result = init(env);
   goto exit_init_caller;
@@ -229,8 +229,8 @@ exit_init_caller:
 }
 
 UNIFEX_TERM test_atom_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   char *in_atom;
   in_atom = NULL;
   if (({
@@ -251,8 +251,8 @@ exit_test_atom_caller:
 }
 
 UNIFEX_TERM test_bool_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   int in_bool;
 
   if (({
@@ -282,8 +282,8 @@ exit_test_bool_caller:
 }
 
 UNIFEX_TERM test_float_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   double in_float;
 
   if (ei_decode_double(in_buff->buff, in_buff->index, &in_float)) {
@@ -300,8 +300,8 @@ exit_test_float_caller:
 }
 
 UNIFEX_TERM test_uint_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   unsigned int in_uint;
 
   if (({
@@ -325,8 +325,8 @@ exit_test_uint_caller:
 }
 
 UNIFEX_TERM test_string_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   char *in_string;
   in_string = NULL;
   if (({
@@ -353,8 +353,8 @@ exit_test_string_caller:
 }
 
 UNIFEX_TERM test_list_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   int *in_list;
   unsigned int in_list_length;
   in_list = NULL;
@@ -423,8 +423,8 @@ exit_test_list_caller:
 
 UNIFEX_TERM test_list_of_strings_caller(UnifexEnv *env,
                                         UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   char **in_strings;
   unsigned int in_strings_length;
   in_strings = NULL;
@@ -501,8 +501,8 @@ exit_test_list_of_strings_caller:
 
 UNIFEX_TERM test_list_of_uints_caller(UnifexEnv *env,
                                       UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   unsigned int *in_uints;
   unsigned int in_uints_length;
   in_uints = NULL;
@@ -574,8 +574,8 @@ exit_test_list_of_uints_caller:
 
 UNIFEX_TERM test_list_with_other_args_caller(UnifexEnv *env,
                                              UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   int *in_list;
   unsigned int in_list_length;
   char *other_param;
@@ -657,8 +657,8 @@ exit_test_list_with_other_args_caller:
 }
 
 UNIFEX_TERM test_payload_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   UnifexPayload *in_payload;
   in_payload = NULL;
   if (unifex_payload_decode(env, in_buff, &in_payload)) {
@@ -679,8 +679,8 @@ exit_test_payload_caller:
 }
 
 UNIFEX_TERM test_pid_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   UnifexPid in_pid;
 
   if (ei_decode_pid(in_buff->buff, in_buff->index, &in_pid)) {
@@ -698,8 +698,8 @@ exit_test_pid_caller:
 
 UNIFEX_TERM test_example_message_caller(UnifexEnv *env,
                                         UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-  UNIFEX_UNUSED(in_buff);
 
   result = test_example_message(env);
   goto exit_test_example_message_caller;

--- a/test/fixtures/nif_ref_generated/nif/example.c
+++ b/test/fixtures/nif_ref_generated/nif/example.c
@@ -138,9 +138,9 @@ static int unifex_load_nif(ErlNifEnv *env, void **priv_data,
 
 static ERL_NIF_TERM export_init(ErlNifEnv *env, int argc,
                                 const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-  UNIFEX_UNUSED(argv);
   UnifexEnv *unifex_env = env;
 
   result = init(unifex_env);
@@ -152,9 +152,9 @@ exit_export_init:
 
 static ERL_NIF_TERM export_test_atom(ErlNifEnv *env, int argc,
                                      const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   char *in_atom;
 
@@ -175,9 +175,9 @@ exit_export_test_atom:
 
 static ERL_NIF_TERM export_test_float(ErlNifEnv *env, int argc,
                                       const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   double in_float;
 
@@ -195,9 +195,9 @@ exit_export_test_float:
 
 static ERL_NIF_TERM export_test_int(ErlNifEnv *env, int argc,
                                     const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   int in_int;
 
@@ -215,9 +215,9 @@ exit_export_test_int:
 
 static ERL_NIF_TERM export_test_list(ErlNifEnv *env, int argc,
                                      const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   int *in_list;
   unsigned int in_list_length;
@@ -263,9 +263,9 @@ exit_export_test_list:
 
 static ERL_NIF_TERM export_test_pid(ErlNifEnv *env, int argc,
                                     const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   UnifexPid in_pid;
 
@@ -283,9 +283,9 @@ exit_export_test_pid:
 
 static ERL_NIF_TERM export_test_state(ErlNifEnv *env, int argc,
                                       const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   UnifexState *state;
 
@@ -303,9 +303,9 @@ exit_export_test_state:
 
 static ERL_NIF_TERM export_test_example_message(ErlNifEnv *env, int argc,
                                                 const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   UnifexPid pid;
 

--- a/test/fixtures/nif_ref_generated/nif/example.cpp
+++ b/test/fixtures/nif_ref_generated/nif/example.cpp
@@ -138,9 +138,9 @@ static int unifex_load_nif(ErlNifEnv *env, void **priv_data,
 
 static ERL_NIF_TERM export_init(ErlNifEnv *env, int argc,
                                 const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-  UNIFEX_UNUSED(argv);
   UnifexEnv *unifex_env = env;
 
   result = init(unifex_env);
@@ -152,9 +152,9 @@ exit_export_init:
 
 static ERL_NIF_TERM export_test_atom(ErlNifEnv *env, int argc,
                                      const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   char *in_atom;
 
@@ -175,9 +175,9 @@ exit_export_test_atom:
 
 static ERL_NIF_TERM export_test_float(ErlNifEnv *env, int argc,
                                       const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   double in_float;
 
@@ -195,9 +195,9 @@ exit_export_test_float:
 
 static ERL_NIF_TERM export_test_int(ErlNifEnv *env, int argc,
                                     const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   int in_int;
 
@@ -215,9 +215,9 @@ exit_export_test_int:
 
 static ERL_NIF_TERM export_test_list(ErlNifEnv *env, int argc,
                                      const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   int *in_list;
   unsigned int in_list_length;
@@ -263,9 +263,9 @@ exit_export_test_list:
 
 static ERL_NIF_TERM export_test_pid(ErlNifEnv *env, int argc,
                                     const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   UnifexPid in_pid;
 
@@ -283,9 +283,9 @@ exit_export_test_pid:
 
 static ERL_NIF_TERM export_test_state(ErlNifEnv *env, int argc,
                                       const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   UnifexState *state;
 
@@ -303,9 +303,9 @@ exit_export_test_state:
 
 static ERL_NIF_TERM export_test_example_message(ErlNifEnv *env, int argc,
                                                 const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   UnifexPid pid;
 

--- a/test/fixtures/unified_ref_generated/cnode/example.c
+++ b/test/fixtures/unified_ref_generated/cnode/example.c
@@ -1,7 +1,10 @@
 #include "example.h"
 #include <stdio.h>
 
-void unifex_cnode_destroy_state(UnifexEnv *env, void *state) {}
+void unifex_cnode_destroy_state(UnifexEnv *env, void *state) {
+  UNIFEX_MAYBE_UNUSED(env);
+  UNIFEX_MAYBE_UNUSED(state);
+}
 
 UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
@@ -18,8 +21,8 @@ UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
 }
 
 UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   int num;
 
   if (({

--- a/test/fixtures/unified_ref_generated/cnode/example.cpp
+++ b/test/fixtures/unified_ref_generated/cnode/example.cpp
@@ -1,7 +1,10 @@
 #include "example.h"
 #include <stdio.h>
 
-void unifex_cnode_destroy_state(UnifexEnv *env, void *state) {}
+void unifex_cnode_destroy_state(UnifexEnv *env, void *state) {
+  UNIFEX_MAYBE_UNUSED(env);
+  UNIFEX_MAYBE_UNUSED(state);
+}
 
 UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
@@ -18,8 +21,8 @@ UNIFEX_TERM foo_result_ok(UnifexEnv *env, int answer) {
 }
 
 UNIFEX_TERM foo_caller(UnifexEnv *env, UnifexCNodeInBuff *in_buff) {
+  UNIFEX_MAYBE_UNUSED(in_buff);
   UNIFEX_TERM result;
-
   int num;
 
   if (({

--- a/test/fixtures/unified_ref_generated/nif/example.c
+++ b/test/fixtures/unified_ref_generated/nif/example.c
@@ -25,9 +25,9 @@ static int unifex_load_nif(ErlNifEnv *env, void **priv_data,
 
 static ERL_NIF_TERM export_foo(ErlNifEnv *env, int argc,
                                const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   int num;
 

--- a/test/fixtures/unified_ref_generated/nif/example.cpp
+++ b/test/fixtures/unified_ref_generated/nif/example.cpp
@@ -25,9 +25,9 @@ static int unifex_load_nif(ErlNifEnv *env, void **priv_data,
 
 static ERL_NIF_TERM export_foo(ErlNifEnv *env, int argc,
                                const ERL_NIF_TERM argv[]) {
-  UNIFEX_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
   ERL_NIF_TERM result;
-
   UnifexEnv *unifex_env = env;
   int num;
 


### PR DESCRIPTION
When the only parameter specified in function in `*.spec.exs` file is user state then compiler warns about unused `in_buff`. This PR fixes this warning. 