### PR TITLE
remove unnecessary C compilation warnigns and update tests

### DIFF
--- a/lib/unifex/code_generator/base_type.ex
+++ b/lib/unifex/code_generator/base_type.ex
@@ -92,7 +92,11 @@ defmodule Unifex.CodeGenerator.BaseType do
   Uses `type` as fallback for `c:generate_native_type/1`
 
   When mode is set to :const_unless_ptr_on_ptr, function will choose to behave like it would be set to :default or :const,
-  depending on value returned by `ptr_level(type, code_generator, ctx)`
+  depending on value returned by `ptr_level(type, code_generator, ctx)`.
+  This mode can be used in places, when in general, you want to have declaration of variable with const type, but using :const
+  mode would generate code, that would require explicit cast to avoid generating warnings during compilation - e.g. in C,
+  passing argument of type `char **` to function, that expects argument of type `char const * const *` without any explicit cast,
+  will generate such a warning
   """
   @spec generate_declaration(
           t,
@@ -165,6 +169,7 @@ defmodule Unifex.CodeGenerator.BaseType do
     call(type, :generate_native_type, [], code_generator, Map.put(ctx, :mode, mode))
   end
 
+  @spec ptr_level(t, module, ctx :: map) :: integer
   def ptr_level(type, code_generator, ctx) do
     call(type, :ptr_level, [], code_generator, ctx)
   end

--- a/lib/unifex/code_generator/base_type.ex
+++ b/lib/unifex/code_generator/base_type.ex
@@ -88,24 +88,12 @@ defmodule Unifex.CodeGenerator.BaseType do
   @spec generate_declaration(
           t,
           name :: atom,
-          mode :: :default | :const | :optional_const,
+          mode :: :default | :const | :const_if_not_ptr_on_ptr,
           module,
           ctx :: map
         ) ::
           [CodeGenerator.code_t()]
   def generate_declaration(type, name, mode \\ :default, code_generator, ctx) do
-    mode =
-      cond do
-        mode in [:default, :const] ->
-          mode
-
-        is_pointer_on_pointer_type(type, code_generator, ctx) ->
-          :default
-
-        true ->
-          :const
-      end
-
     generate_native_type(type, mode, code_generator, ctx)
     |> Bunch.listify()
     |> Enum.map(fn
@@ -159,19 +147,6 @@ defmodule Unifex.CodeGenerator.BaseType do
 
   def generate_native_type(type, mode \\ :default, code_generator, ctx) do
     call(type, :generate_native_type, [], code_generator, Map.put(ctx, :mode, mode))
-  end
-
-  defp is_pointer_on_pointer_type(type, code_generator, ctx) do
-    generate_native_type(type, code_generator, ctx)
-    |> Bunch.listify()
-    |> Enum.map(fn
-      {native_type, _sufix} -> native_type
-      native_type -> native_type
-    end)
-    |> Enum.map(fn native_type -> String.replace(native_type, " ", "") end)
-    |> Enum.map(fn native_type -> String.replace(native_type, "const", "") end)
-    |> Enum.find(fn native_type -> String.match?(native_type, ~r"\*\*$") end)
-    |> is_binary()
   end
 
   defp call(full_type, callback, args, code_generator, ctx) do

--- a/lib/unifex/code_generator/base_type.ex
+++ b/lib/unifex/code_generator/base_type.ex
@@ -85,7 +85,13 @@ defmodule Unifex.CodeGenerator.BaseType do
 
   Uses `type` as fallback for `c:generate_native_type/1`
   """
-  @spec generate_declaration(t, name :: atom, mode :: :default | :const | :optional_const, module, ctx :: map) ::
+  @spec generate_declaration(
+          t,
+          name :: atom,
+          mode :: :default | :const | :optional_const,
+          module,
+          ctx :: map
+        ) ::
           [CodeGenerator.code_t()]
   def generate_declaration(type, name, mode \\ :default, code_generator, ctx) do
     mode =
@@ -99,7 +105,6 @@ defmodule Unifex.CodeGenerator.BaseType do
         true ->
           :const
       end
-
 
     generate_native_type(type, mode, code_generator, ctx)
     |> Bunch.listify()

--- a/lib/unifex/code_generator/base_types/atom.ex
+++ b/lib/unifex/code_generator/base_types/atom.ex
@@ -11,8 +11,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.Atom do
 
   @impl BaseType
   def generate_native_type(ctx) do
-    prefix = if ctx.mode == :const, do: "const ", else: ""
-    ~g<#{prefix} char*>
+    optional_const = if ctx.mode in [:const, :const_if_not_ptr_on_ptr], do: "const ", else: ""
+    ~g<char #{optional_const} *>
   end
 
   @impl BaseType

--- a/lib/unifex/code_generator/base_types/atom.ex
+++ b/lib/unifex/code_generator/base_types/atom.ex
@@ -10,8 +10,11 @@ defmodule Unifex.CodeGenerator.BaseTypes.Atom do
   alias Unifex.CodeGenerator.BaseType
 
   @impl BaseType
+  def ptr_level(_ctx), do: 1
+
+  @impl BaseType
   def generate_native_type(ctx) do
-    optional_const = if ctx.mode in [:const, :const_if_not_ptr_on_ptr], do: "const ", else: ""
+    optional_const = if ctx.mode == :const, do: "const ", else: ""
     ~g<char #{optional_const} *>
   end
 

--- a/lib/unifex/code_generator/base_types/default.ex
+++ b/lib/unifex/code_generator/base_types/default.ex
@@ -9,6 +9,9 @@ defmodule Unifex.CodeGenerator.BaseTypes.Default do
   alias Unifex.CodeGenerator.BaseType
 
   @impl BaseType
+  def ptr_level(_ctx), do: 0
+
+  @impl BaseType
   def generate_native_type(ctx) do
     ~g<#{ctx.type}>
   end

--- a/lib/unifex/code_generator/base_types/list.ex
+++ b/lib/unifex/code_generator/base_types/list.ex
@@ -11,25 +11,11 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
   alias Unifex.CodeGenerator.BaseType
 
   @impl BaseType
-  def generate_native_type(ctx)
-
-  def generate_native_type(%{mode: :const_if_not_ptr_on_ptr} = ctx) do
-    ptr? =
-      BaseType.generate_native_type(ctx.subtype, ctx.mode, ctx.generator, %{ctx | mode: :default})
-      |> String.replace(" ", "")
-      |> String.match?(~r"\*$")
-
-    mode = if not ptr?, do: :const, else: :default
-    ctx = %{ctx | mode: mode}
-
-    [
-      "#{BaseType.generate_native_type(ctx.subtype, ctx.mode, ctx.generator, ctx)} #{
-        if not ptr?, do: "const"
-      }*",
-      {"unsigned int", "_length"}
-    ]
+  def ptr_level(ctx) do
+    BaseType.ptr_level(ctx.subtype, ctx.generator, ctx) + 1
   end
 
+  @impl BaseType
   def generate_native_type(ctx) do
     optional_const = if ctx.mode == :const, do: "const ", else: ""
 

--- a/lib/unifex/code_generator/base_types/list.ex
+++ b/lib/unifex/code_generator/base_types/list.ex
@@ -11,6 +11,25 @@ defmodule Unifex.CodeGenerator.BaseTypes.List do
   alias Unifex.CodeGenerator.BaseType
 
   @impl BaseType
+  def generate_native_type(ctx)
+
+  def generate_native_type(%{mode: :const_if_not_ptr_on_ptr} = ctx) do
+    ptr? =
+      BaseType.generate_native_type(ctx.subtype, ctx.mode, ctx.generator, %{ctx | mode: :default})
+      |> String.replace(" ", "")
+      |> String.match?(~r"\*$")
+
+    mode = if not ptr?, do: :const, else: :default
+    ctx = %{ctx | mode: mode}
+
+    [
+      "#{BaseType.generate_native_type(ctx.subtype, ctx.mode, ctx.generator, ctx)} #{
+        if not ptr?, do: "const"
+      }*",
+      {"unsigned int", "_length"}
+    ]
+  end
+
   def generate_native_type(ctx) do
     optional_const = if ctx.mode == :const, do: "const ", else: ""
 

--- a/lib/unifex/code_generator/base_types/payload.ex
+++ b/lib/unifex/code_generator/base_types/payload.ex
@@ -8,6 +8,9 @@ defmodule Unifex.CodeGenerator.BaseTypes.Payload do
   alias Unifex.CodeGenerator.BaseType
 
   @impl BaseType
+  def ptr_level(_ctx), do: 1
+
+  @impl BaseType
   def generate_native_type(_ctx) do
     ~g<UnifexPayload *>
   end

--- a/lib/unifex/code_generator/base_types/state.ex
+++ b/lib/unifex/code_generator/base_types/state.ex
@@ -8,6 +8,9 @@ defmodule Unifex.CodeGenerator.BaseTypes.State do
   alias Unifex.CodeGenerator.BaseType
 
   @impl BaseType
+  def ptr_level(_ctx), do: 1
+
+  @impl BaseType
   def generate_native_type(_ctx) do
     ~g<UnifexState*>
   end

--- a/lib/unifex/code_generator/base_types/string.ex
+++ b/lib/unifex/code_generator/base_types/string.ex
@@ -10,8 +10,11 @@ defmodule Unifex.CodeGenerator.BaseTypes.String do
   alias Unifex.CodeGenerator.BaseType
 
   @impl BaseType
+  def ptr_level(_ctx), do: 1
+
+  @impl BaseType
   def generate_native_type(ctx) do
-    optional_const = if ctx.mode in [:const, :const_if_not_ptr_on_ptr], do: "const ", else: ""
+    optional_const = if ctx.mode == :const, do: "const ", else: ""
     ~g<char #{optional_const}*>
   end
 

--- a/lib/unifex/code_generator/base_types/string.ex
+++ b/lib/unifex/code_generator/base_types/string.ex
@@ -11,7 +11,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.String do
 
   @impl BaseType
   def generate_native_type(ctx) do
-    optional_const = if ctx.mode == :const, do: "const ", else: ""
+    optional_const = if ctx.mode in [:const, :const_if_not_ptr_on_ptr], do: "const ", else: ""
     ~g<char #{optional_const}*>
   end
 

--- a/lib/unifex/code_generators/cnode.ex
+++ b/lib/unifex/code_generators/cnode.ex
@@ -138,7 +138,8 @@ defmodule Unifex.CodeGenerators.CNode do
     args = meta |> Keyword.get_values(:arg)
 
     args_declarations =
-      ["UnifexEnv * env" | generate_args_declarations(args, :const, ctx)] |> Enum.join(", ")
+      [~g<UnifexEnv* env> | generate_args_declarations(args, :const, ctx)]
+      |> Enum.join(", ")
 
     labels = meta |> Keyword.get_values(:label)
     fun_name = [name, "result" | labels] |> Enum.join("_")
@@ -199,7 +200,11 @@ defmodule Unifex.CodeGenerators.CNode do
 
   defp generate_args_declarations(args, mode \\ :default, ctx) do
     Enum.flat_map(args, fn {name, type} ->
-      BaseType.generate_declaration(type, name, mode, CNode, ctx)
+      if Common.is_pointer_on_pointer_type(type, CNode, ctx) do
+        BaseType.generate_declaration(type, name, :default, CNode, ctx)
+      else
+        BaseType.generate_declaration(type, name, mode, CNode, ctx)
+      end
     end)
   end
 

--- a/lib/unifex/code_generators/cnode.ex
+++ b/lib/unifex/code_generators/cnode.ex
@@ -138,7 +138,7 @@ defmodule Unifex.CodeGenerators.CNode do
     args = meta |> Keyword.get_values(:arg)
 
     args_declarations =
-      [~g<UnifexEnv* env> | generate_args_declarations(args, :const_if_not_ptr_on_ptr, ctx)]
+      [~g<UnifexEnv* env> | generate_args_declarations(args, :const_unless_ptr_on_ptr, ctx)]
       |> Enum.join(", ")
 
     labels = meta |> Keyword.get_values(:label)
@@ -170,7 +170,7 @@ defmodule Unifex.CodeGenerators.CNode do
       [
         ~g<UnifexEnv * env>,
         ~g<UnifexPid pid>,
-        ~g<int flags> | generate_args_declarations(args, :const_if_not_ptr_on_ptr, ctx)
+        ~g<int flags> | generate_args_declarations(args, :const_unless_ptr_on_ptr, ctx)
       ]
       |> Enum.join(", ")
 

--- a/lib/unifex/code_generators/cnode.ex
+++ b/lib/unifex/code_generators/cnode.ex
@@ -138,7 +138,7 @@ defmodule Unifex.CodeGenerators.CNode do
     args = meta |> Keyword.get_values(:arg)
 
     args_declarations =
-      [~g<UnifexEnv* env> | generate_args_declarations(args, :optional_const, ctx)]
+      [~g<UnifexEnv* env> | generate_args_declarations(args, :const_if_not_ptr_on_ptr, ctx)]
       |> Enum.join(", ")
 
     labels = meta |> Keyword.get_values(:label)
@@ -170,7 +170,7 @@ defmodule Unifex.CodeGenerators.CNode do
       [
         ~g<UnifexEnv * env>,
         ~g<UnifexPid pid>,
-        ~g<int flags> | generate_args_declarations(args, :optional_const, ctx)
+        ~g<int flags> | generate_args_declarations(args, :const_if_not_ptr_on_ptr, ctx)
       ]
       |> Enum.join(", ")
 

--- a/lib/unifex/code_generators/cnode.ex
+++ b/lib/unifex/code_generators/cnode.ex
@@ -138,7 +138,7 @@ defmodule Unifex.CodeGenerators.CNode do
     args = meta |> Keyword.get_values(:arg)
 
     args_declarations =
-      [~g<UnifexEnv* env> | generate_args_declarations(args, :const, ctx)]
+      [~g<UnifexEnv* env> | generate_args_declarations(args, :optional_const, ctx)]
       |> Enum.join(", ")
 
     labels = meta |> Keyword.get_values(:label)
@@ -170,7 +170,7 @@ defmodule Unifex.CodeGenerators.CNode do
       [
         ~g<UnifexEnv * env>,
         ~g<UnifexPid pid>,
-        ~g<int flags> | generate_args_declarations(args, :const, ctx)
+        ~g<int flags> | generate_args_declarations(args, :optional_const, ctx)
       ]
       |> Enum.join(", ")
 
@@ -200,11 +200,7 @@ defmodule Unifex.CodeGenerators.CNode do
 
   defp generate_args_declarations(args, mode \\ :default, ctx) do
     Enum.flat_map(args, fn {name, type} ->
-      if Common.is_pointer_on_pointer_type(type, CNode, ctx) do
-        BaseType.generate_declaration(type, name, :default, CNode, ctx)
-      else
-        BaseType.generate_declaration(type, name, mode, CNode, ctx)
-      end
+      BaseType.generate_declaration(type, name, mode, CNode, ctx)
     end)
   end
 

--- a/lib/unifex/code_generators/common.ex
+++ b/lib/unifex/code_generators/common.ex
@@ -57,4 +57,17 @@ defmodule Unifex.CodeGenerators.Common do
     #endif
     """
   end
+
+  def is_pointer_on_pointer_type(type, code_generator, ctx) do
+    BaseType.generate_native_type(type, code_generator, ctx)
+    |> Bunch.listify()
+    |> Enum.map(fn
+      {native_type, _sufix} -> native_type
+      native_type -> native_type
+    end)
+    |> Enum.map(fn native_type -> String.replace(native_type, " ", "") end)
+    |> Enum.map(fn native_type -> String.replace(native_type, "const", "") end)
+    |> Enum.find(fn native_type -> String.match?(native_type, ~r"\*\*$") end)
+    |> is_binary()
+  end
 end

--- a/lib/unifex/code_generators/common.ex
+++ b/lib/unifex/code_generators/common.ex
@@ -57,17 +57,4 @@ defmodule Unifex.CodeGenerators.Common do
     #endif
     """
   end
-
-  def is_pointer_on_pointer_type(type, code_generator, ctx) do
-    BaseType.generate_native_type(type, code_generator, ctx)
-    |> Bunch.listify()
-    |> Enum.map(fn
-      {native_type, _sufix} -> native_type
-      native_type -> native_type
-    end)
-    |> Enum.map(fn native_type -> String.replace(native_type, " ", "") end)
-    |> Enum.map(fn native_type -> String.replace(native_type, "const", "") end)
-    |> Enum.find(fn native_type -> String.match?(native_type, ~r"\*\*$") end)
-    |> is_binary()
-  end
 end

--- a/lib/unifex/code_generators/nif.ex
+++ b/lib/unifex/code_generators/nif.ex
@@ -154,7 +154,7 @@ defmodule Unifex.CodeGenerators.NIF do
     labels = meta |> Keyword.get_values(:label)
 
     args_declarations =
-      [~g<UnifexEnv* env> | generate_args_declarations(args, :const_if_not_ptr_on_ptr, ctx)]
+      [~g<UnifexEnv* env> | generate_args_declarations(args, :const_unless_ptr_on_ptr, ctx)]
       |> Enum.join(", ")
 
     ~g<UNIFEX_TERM #{[name, :result | labels] |> Enum.join("_")}(#{args_declarations})>
@@ -182,7 +182,7 @@ defmodule Unifex.CodeGenerators.NIF do
         ~g<UnifexEnv* env>,
         ~g<UnifexPid pid>,
         ~g<int flags>
-        | generate_args_declarations(args, :const_if_not_ptr_on_ptr, ctx)
+        | generate_args_declarations(args, :const_unless_ptr_on_ptr, ctx)
       ]
       |> Enum.join(", ")
 

--- a/lib/unifex/code_generators/nif.ex
+++ b/lib/unifex/code_generators/nif.ex
@@ -133,11 +133,7 @@ defmodule Unifex.CodeGenerators.NIF do
 
   defp generate_args_declarations(args, mode, ctx) do
     Enum.flat_map(args, fn {name, type} ->
-      if Common.is_pointer_on_pointer_type(type, NIF, ctx) do
-        BaseType.generate_declaration(type, name, :default, NIF, ctx)
-      else
-        BaseType.generate_declaration(type, name, mode, NIF, ctx)
-      end
+      BaseType.generate_declaration(type, name, mode, NIF, ctx)
     end)
   end
 
@@ -158,7 +154,7 @@ defmodule Unifex.CodeGenerators.NIF do
     labels = meta |> Keyword.get_values(:label)
 
     args_declarations =
-      [~g<UnifexEnv* env> | generate_args_declarations(args, :const, ctx)]
+      [~g<UnifexEnv* env> | generate_args_declarations(args, :optional_const, ctx)]
       |> Enum.join(", ")
 
     ~g<UNIFEX_TERM #{[name, :result | labels] |> Enum.join("_")}(#{args_declarations})>
@@ -186,7 +182,7 @@ defmodule Unifex.CodeGenerators.NIF do
         ~g<UnifexEnv* env>,
         ~g<UnifexPid pid>,
         ~g<int flags>
-        | generate_args_declarations(args, :const, ctx)
+        | generate_args_declarations(args, :optional_const, ctx)
       ]
       |> Enum.join(", ")
 

--- a/lib/unifex/code_generators/nif.ex
+++ b/lib/unifex/code_generators/nif.ex
@@ -154,7 +154,7 @@ defmodule Unifex.CodeGenerators.NIF do
     labels = meta |> Keyword.get_values(:label)
 
     args_declarations =
-      [~g<UnifexEnv* env> | generate_args_declarations(args, :optional_const, ctx)]
+      [~g<UnifexEnv* env> | generate_args_declarations(args, :const_if_not_ptr_on_ptr, ctx)]
       |> Enum.join(", ")
 
     ~g<UNIFEX_TERM #{[name, :result | labels] |> Enum.join("_")}(#{args_declarations})>
@@ -182,7 +182,7 @@ defmodule Unifex.CodeGenerators.NIF do
         ~g<UnifexEnv* env>,
         ~g<UnifexPid pid>,
         ~g<int flags>
-        | generate_args_declarations(args, :optional_const, ctx)
+        | generate_args_declarations(args, :const_if_not_ptr_on_ptr, ctx)
       ]
       |> Enum.join(", ")
 

--- a/lib/unifex/code_generators/nif.ex
+++ b/lib/unifex/code_generators/nif.ex
@@ -131,6 +131,16 @@ defmodule Unifex.CodeGenerators.NIF do
     ~g<UNIFEX_TERM #{name}(#{args_declarations})>
   end
 
+  defp generate_args_declarations(args, mode, ctx) do
+    Enum.flat_map(args, fn {name, type} ->
+      if Common.is_pointer_on_pointer_type(type, NIF, ctx) do
+        BaseType.generate_declaration(type, name, :default, NIF, ctx)
+      else
+        BaseType.generate_declaration(type, name, mode, NIF, ctx)
+      end
+    end)
+  end
+
   defp generate_result_function({name, result}, ctx) do
     declaration = generate_result_function_declaration({name, result}, ctx)
     {result, _meta} = generate_serialization(result, ctx)
@@ -148,13 +158,7 @@ defmodule Unifex.CodeGenerators.NIF do
     labels = meta |> Keyword.get_values(:label)
 
     args_declarations =
-      [
-        ~g<UnifexEnv* env>
-        | args
-          |> Enum.flat_map(fn {name, type} ->
-            BaseType.generate_declaration(type, name, :const, NIF, ctx)
-          end)
-      ]
+      [~g<UnifexEnv* env> | generate_args_declarations(args, :const, ctx)]
       |> Enum.join(", ")
 
     ~g<UNIFEX_TERM #{[name, :result | labels] |> Enum.join("_")}(#{args_declarations})>
@@ -182,9 +186,7 @@ defmodule Unifex.CodeGenerators.NIF do
         ~g<UnifexEnv* env>,
         ~g<UnifexPid pid>,
         ~g<int flags>
-        | Enum.flat_map(args, fn {name, type} ->
-            BaseType.generate_declaration(type, name, :const, NIF, ctx)
-          end)
+        | generate_args_declarations(args, :const, ctx)
       ]
       |> Enum.join(", ")
 

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -107,8 +107,7 @@ UNIFEX_TERM test_list_result_ok(UnifexEnv *env, int const *out_list,
   return out_buff;
 }
 
-UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env,
-                                           char const *const *out_strings,
+UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env, char **out_strings,
                                            unsigned int out_strings_length) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -28,7 +28,7 @@ UNIFEX_TERM init_result_ok(UnifexEnv *env, UnifexState *state) {
   return out_buff;
 }
 
-UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom) {
+UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, char const *out_atom) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
 
@@ -150,7 +150,7 @@ UNIFEX_TERM test_list_of_uints_result_ok(UnifexEnv *env,
 UNIFEX_TERM test_list_with_other_args_result_ok(UnifexEnv *env,
                                                 int const *out_list,
                                                 unsigned int out_list_length,
-                                                const char *other_param) {
+                                                char const *other_param) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
 
@@ -205,7 +205,7 @@ UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env) {
 }
 
 UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
-                                              const char *reason) {
+                                              char const *reason) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
 

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -107,8 +107,7 @@ UNIFEX_TERM test_list_result_ok(UnifexEnv *env, int const *out_list,
   return out_buff;
 }
 
-UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env,
-                                           char const *const *out_strings,
+UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env, char **out_strings,
                                            unsigned int out_strings_length) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -28,7 +28,7 @@ UNIFEX_TERM init_result_ok(UnifexEnv *env, UnifexState *state) {
   return out_buff;
 }
 
-UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom) {
+UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, char const *out_atom) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
 
@@ -150,7 +150,7 @@ UNIFEX_TERM test_list_of_uints_result_ok(UnifexEnv *env,
 UNIFEX_TERM test_list_with_other_args_result_ok(UnifexEnv *env,
                                                 int const *out_list,
                                                 unsigned int out_list_length,
-                                                const char *other_param) {
+                                                char const *other_param) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
 
@@ -205,7 +205,7 @@ UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env) {
 }
 
 UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
-                                              const char *reason) {
+                                              char const *reason) {
   UNIFEX_TERM out_buff = (ei_x_buff *)malloc(sizeof(ei_x_buff));
   unifex_cnode_prepare_ei_x_buff(env, out_buff, "result");
 

--- a/test/fixtures/cnode_ref_generated/cnode/example.h
+++ b/test/fixtures/cnode_ref_generated/cnode/example.h
@@ -79,7 +79,7 @@ UNIFEX_TERM test_example_message(UnifexEnv *env);
 UNIFEX_TERM test_my_struct(UnifexEnv *env, my_struct in_struct);
 UNIFEX_TERM test_nested_struct(UnifexEnv *env, nested_struct in_struct);
 UNIFEX_TERM init_result_ok(UnifexEnv *env, UnifexState *state);
-UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom);
+UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, char const *out_atom);
 UNIFEX_TERM test_bool_result_ok(UnifexEnv *env, int out_bool);
 UNIFEX_TERM test_float_result_ok(UnifexEnv *env, double out_float);
 UNIFEX_TERM test_uint_result_ok(UnifexEnv *env, unsigned int out_uint);
@@ -94,12 +94,12 @@ UNIFEX_TERM test_list_of_uints_result_ok(UnifexEnv *env,
 UNIFEX_TERM test_list_with_other_args_result_ok(UnifexEnv *env,
                                                 int const *out_list,
                                                 unsigned int out_list_length,
-                                                const char *other_param);
+                                                char const *other_param);
 UNIFEX_TERM test_payload_result_ok(UnifexEnv *env, UnifexPayload *out_payload);
 UNIFEX_TERM test_pid_result_ok(UnifexEnv *env, UnifexPid out_pid);
 UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env);
 UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
-                                              const char *reason);
+                                              char const *reason);
 UNIFEX_TERM test_my_struct_result_ok(UnifexEnv *env, my_struct out_struct);
 UNIFEX_TERM test_nested_struct_result_ok(UnifexEnv *env,
                                          nested_struct out_struct);

--- a/test/fixtures/cnode_ref_generated/cnode/example.h
+++ b/test/fixtures/cnode_ref_generated/cnode/example.h
@@ -86,8 +86,7 @@ UNIFEX_TERM test_uint_result_ok(UnifexEnv *env, unsigned int out_uint);
 UNIFEX_TERM test_string_result_ok(UnifexEnv *env, char const *out_string);
 UNIFEX_TERM test_list_result_ok(UnifexEnv *env, int const *out_list,
                                 unsigned int out_list_length);
-UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env,
-                                           char const *const *out_strings,
+UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env, char **out_strings,
                                            unsigned int out_strings_length);
 UNIFEX_TERM test_list_of_uints_result_ok(UnifexEnv *env,
                                          unsigned int const *out_uints,

--- a/test/fixtures/nif_ref_generated/nif/example.c
+++ b/test/fixtures/nif_ref_generated/nif/example.c
@@ -10,7 +10,7 @@ UNIFEX_TERM init_result_ok(UnifexEnv *env, int was_handle_load_called,
   });
 }
 
-UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom) {
+UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, char const *out_atom) {
   return ({
     const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
                                   enif_make_atom(env, out_atom)};
@@ -102,7 +102,7 @@ UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env) {
 }
 
 UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
-                                              const char *reason) {
+                                              char const *reason) {
   return ({
     const ERL_NIF_TERM terms[] = {enif_make_atom(env, "error"),
                                   enif_make_atom(env, reason)};

--- a/test/fixtures/nif_ref_generated/nif/example.cpp
+++ b/test/fixtures/nif_ref_generated/nif/example.cpp
@@ -10,7 +10,7 @@ UNIFEX_TERM init_result_ok(UnifexEnv *env, int was_handle_load_called,
   });
 }
 
-UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom) {
+UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, char const *out_atom) {
   return ({
     const ERL_NIF_TERM terms[] = {enif_make_atom(env, "ok"),
                                   enif_make_atom(env, out_atom)};
@@ -102,7 +102,7 @@ UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env) {
 }
 
 UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
-                                              const char *reason) {
+                                              char const *reason) {
   return ({
     const ERL_NIF_TERM terms[] = {enif_make_atom(env, "error"),
                                   enif_make_atom(env, reason)};

--- a/test/fixtures/nif_ref_generated/nif/example.h
+++ b/test/fixtures/nif_ref_generated/nif/example.h
@@ -109,7 +109,7 @@ int handle_load(UnifexEnv *env, void **priv_data);
 
 UNIFEX_TERM init_result_ok(UnifexEnv *env, int was_handle_load_called,
                            UnifexState *state);
-UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom);
+UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, char const *out_atom);
 UNIFEX_TERM test_float_result_ok(UnifexEnv *env, double out_float);
 UNIFEX_TERM test_int_result_ok(UnifexEnv *env, int out_int);
 UNIFEX_TERM test_string_result_ok(UnifexEnv *env, char const *out_string);
@@ -121,7 +121,7 @@ UNIFEX_TERM test_pid_result_ok(UnifexEnv *env, UnifexPid out_pid);
 UNIFEX_TERM test_state_result_ok(UnifexEnv *env, UnifexState *state);
 UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env);
 UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
-                                              const char *reason);
+                                              char const *reason);
 UNIFEX_TERM test_my_struct_result_ok(UnifexEnv *env, my_struct out_struct);
 UNIFEX_TERM test_nested_struct_result_ok(UnifexEnv *env,
                                          nested_struct out_struct);

--- a/test/fixtures/nif_ref_generated/nif/example.h
+++ b/test/fixtures/nif_ref_generated/nif/example.h
@@ -84,8 +84,11 @@ UNIFEX_TERM init(UnifexEnv *env);
 UNIFEX_TERM test_atom(UnifexEnv *env, char *in_atom);
 UNIFEX_TERM test_float(UnifexEnv *env, double in_float);
 UNIFEX_TERM test_int(UnifexEnv *env, int in_int);
+UNIFEX_TERM test_string(UnifexEnv *env, char *in_string);
 UNIFEX_TERM test_list(UnifexEnv *env, int *in_list,
                       unsigned int in_list_length);
+UNIFEX_TERM test_list_of_strings(UnifexEnv *env, char **in_strings,
+                                 unsigned int in_strings_length);
 UNIFEX_TERM test_pid(UnifexEnv *env, UnifexPid in_pid);
 UNIFEX_TERM test_state(UnifexEnv *env, UnifexState *state);
 UNIFEX_TERM test_example_message(UnifexEnv *env, UnifexPid pid);
@@ -109,8 +112,11 @@ UNIFEX_TERM init_result_ok(UnifexEnv *env, int was_handle_load_called,
 UNIFEX_TERM test_atom_result_ok(UnifexEnv *env, const char *out_atom);
 UNIFEX_TERM test_float_result_ok(UnifexEnv *env, double out_float);
 UNIFEX_TERM test_int_result_ok(UnifexEnv *env, int out_int);
+UNIFEX_TERM test_string_result_ok(UnifexEnv *env, char const *out_string);
 UNIFEX_TERM test_list_result_ok(UnifexEnv *env, int const *out_list,
                                 unsigned int out_list_length);
+UNIFEX_TERM test_list_of_strings_result_ok(UnifexEnv *env, char **out_strings,
+                                           unsigned int out_strings_length);
 UNIFEX_TERM test_pid_result_ok(UnifexEnv *env, UnifexPid out_pid);
 UNIFEX_TERM test_state_result_ok(UnifexEnv *env, UnifexState *state);
 UNIFEX_TERM test_example_message_result_ok(UnifexEnv *env);

--- a/test_projects/cnode/bundlex.exs
+++ b/test_projects/cnode/bundlex.exs
@@ -3,16 +3,17 @@ defmodule Example.BundlexProject do
 
   def project() do
     [
-      cnodes: cnodes(Bundlex.platform())
+      natives: natives(Bundlex.platform())
     ]
   end
 
-  def cnodes(_platform) do
+  def natives(_platform) do
     [
       example: [
         src_base: "example",
         sources: ["example.c"],
-        preprocessor: Unifex
+        preprocessor: Unifex,
+        interface: :cnode
       ]
     ]
   end

--- a/test_projects/nif/bundlex.exs
+++ b/test_projects/nif/bundlex.exs
@@ -3,16 +3,17 @@ defmodule Example.BundlexProject do
 
   def project() do
     [
-      nifs: nifs(Bundlex.platform())
+      natives: natives(Bundlex.platform())
     ]
   end
 
-  def nifs(_platform) do
+  def natives(_platform) do
     [
       example: [
         src_base: "example",
         sources: ["example.c"],
-        preprocessor: Unifex
+        preprocessor: Unifex,
+        interface: :nif
       ]
     ]
   end

--- a/test_projects/nif/c_src/example/example.c
+++ b/test_projects/nif/c_src/example/example.c
@@ -29,8 +29,17 @@ UNIFEX_TERM test_int(UnifexEnv *env, int in_int) {
   return test_int_result_ok(env, in_int);
 }
 
+UNIFEX_TERM test_string(UnifexEnv *env, char *str) {
+  return test_string_result_ok(env, str);
+}
+
 UNIFEX_TERM test_list(UnifexEnv *env, int *in_list, unsigned int list_length) {
   return test_list_result_ok(env, in_list, list_length);
+}
+
+UNIFEX_TERM test_list_of_strings(UnifexEnv *env, char **in_strings,
+                                 unsigned int list_length) {
+  return test_list_of_strings_result_ok(env, in_strings, list_length);
 }
 
 UNIFEX_TERM test_pid(UnifexEnv *env, UnifexPid in_pid) {

--- a/test_projects/nif/c_src/example/example.spec.exs
+++ b/test_projects/nif/c_src/example/example.spec.exs
@@ -14,7 +14,11 @@ spec test_float(in_float :: float) :: {:ok :: label, out_float :: float}
 
 spec test_int(in_int :: int) :: {:ok :: label, out_int :: int}
 
+spec test_string(in_string :: string) :: {:ok :: label, out_string :: string}
+
 spec test_list(in_list :: [int]) :: {:ok :: label, out_list :: [int]}
+
+spec test_list_of_strings(in_strings :: [string]) :: {:ok :: label, out_strings :: [string]}
 
 spec test_pid(in_pid :: pid) :: {:ok :: label, out_pid :: pid}
 

--- a/test_projects/nif/test/example_test.exs
+++ b/test_projects/nif/test/example_test.exs
@@ -23,8 +23,17 @@ defmodule ExampleTest do
     assert {:ok, 10} = Example.test_int(10)
   end
 
+  test "string" do
+    assert {:ok, "unifex"} = Example.test_string("unifex")
+  end
+
   test "list" do
     assert {:ok, [1, 2, 3]} = Example.test_list([1, 2, 3])
+  end
+
+  test "list of strings" do
+    l = ["unifex", "is", "really", "cool"]
+    assert {:ok, ^l} = Example.test_list_of_strings(l)
   end
 
   test "pid" do


### PR DESCRIPTION
Fixing a bug based on showing unnecessary warnings from `gcc` during compilation