### PR TITLE
Implement thread API for C node. Change `UnifexPayload` API.

### DIFF
--- a/bundlex.exs
+++ b/bundlex.exs
@@ -18,6 +18,7 @@ defmodule Unifex.BundlexProject do
       unifex: [
         src_base: "unifex/cnode/unifex",
         sources: ["unifex.c", "cnode.c", "payload.c"],
+        libs: ["pthread"],
         interface: :cnode
       ]
     ]

--- a/c_src/unifex/cnode/unifex/payload.c
+++ b/c_src/unifex/cnode/unifex/payload.c
@@ -30,20 +30,24 @@ void unifex_payload_encode(UnifexEnv *env, UNIFEX_TERM buff,
   env->error = unifex_raise(env, "unifex_payload_encode");
 }
 
-UnifexPayload *unifex_payload_alloc(UnifexEnv *_env, UnifexPayloadType type,
-                                    unsigned int size) {
+int unifex_payload_alloc(UnifexEnv *_env, UnifexPayloadType type,
+                                    unsigned int size, UnifexPayload *payload) {
   UNIFEX_UNUSED(_env);
-  UnifexPayload *payload = unifex_alloc(sizeof(UnifexPayload));
-  payload->type = type;
-  payload->size = size;
-  payload->owned = 1;
 
   switch (type) {
   case UNIFEX_PAYLOAD_BINARY:
     payload->data = unifex_alloc(size);
+    if (!payload->data) {
+      return 0;
+    }
     break;
   }
-  return payload;
+
+  payload->type = type;
+  payload->size = size;
+  payload->owned = 1;
+
+  return 1;
 }
 
 void unifex_payload_release(UnifexPayload *payload) {
@@ -58,6 +62,4 @@ void unifex_payload_release(UnifexPayload *payload) {
     }
     break;
   }
-
-  unifex_free(payload);
 }

--- a/c_src/unifex/cnode/unifex/payload.h
+++ b/c_src/unifex/cnode/unifex/payload.h
@@ -19,8 +19,8 @@ struct _UnifexPayload {
 };
 typedef struct _UnifexPayload UnifexPayload;
 
-UnifexPayload *unifex_payload_alloc(UnifexEnv *env, UnifexPayloadType type,
-                                    unsigned int size);
+int unifex_payload_alloc(UnifexEnv *env, UnifexPayloadType type,
+                                    unsigned int size, UnifexPayload *payload);
 int unifex_payload_decode(UnifexEnv *env, UnifexCNodeInBuff *buff,
                           UnifexPayload **payload);
 void unifex_payload_encode(UnifexEnv *env, UNIFEX_TERM buff,

--- a/c_src/unifex/cnode/unifex/unifex.h
+++ b/c_src/unifex/cnode/unifex/unifex.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <pthread.h>
 
 // required for ei.h to work
 #ifndef _REENTRANT
@@ -53,6 +54,21 @@ static inline void unifex_free_env(UnifexEnv *_env) { UNIFEX_UNUSED(_env); }
 static inline UnifexPid *unifex_self(UnifexEnv *env, UnifexPid *pid) {
   return (UnifexPid *) memcpy(pid, env->reply_to, sizeof(UnifexPid));
 };
+
+// Threads
+typedef pthread_t UnifexTid;
+static inline int unifex_thread_create(char *name, UnifexTid *tid, void *(*func)(void *), void *args) {
+  UNIFEX_UNUSED(name);
+  return pthread_create(tid, NULL, func, args);
+}
+
+static inline void unifex_thread_exit(void *exit_val) {
+  pthread_exit(exit_val);
+}
+
+static inline int unifex_thread_join(UnifexTid tid, void **exit_val) {
+  return pthread_join(tid, exit_val);
+}
 
 UNIFEX_TERM unifex_raise(UnifexEnv *env, const char *message);
 

--- a/c_src/unifex/cnode/unifex/unifex.h
+++ b/c_src/unifex/cnode/unifex/unifex.h
@@ -45,22 +45,12 @@ static inline void *unifex_alloc(size_t size) { return malloc(size); }
 
 static inline void unifex_free(void *pointer) { free(pointer); }
 
-/**
- * Env
- * 
- * These functions are introduced to achieve interoperability between NIF and C node.
- * They does nothing.
-*/
+// Env
 static inline UnifexEnv *unifex_alloc_env(UnifexEnv *env) { return env; }
 static inline void unifex_clear_env(UnifexEnv *_env) { UNIFEX_UNUSED(_env); }
 static inline void unifex_free_env(UnifexEnv *_env) { UNIFEX_UNUSED(_env); }
 
-/** 
- * Threads
- * 
- * To use these functions compile and link with -pthread.
- * Refer to bundlex project documentation to see how to do it.
-*/
+// Threads
 typedef pthread_t UnifexTid;
 static inline int unifex_thread_create(char *name, UnifexTid *tid, void *(*func)(void *), void *args) {
   UNIFEX_UNUSED(name);

--- a/c_src/unifex/cnode/unifex/unifex.h
+++ b/c_src/unifex/cnode/unifex/unifex.h
@@ -45,30 +45,38 @@ static inline void *unifex_alloc(size_t size) { return malloc(size); }
 
 static inline void unifex_free(void *pointer) { free(pointer); }
 
+/**
+ * Env
+ * 
+ * These functions are introduced to achieve interoperability between NIF and C node.
+ * They does nothing.
+*/
 static inline UnifexEnv *unifex_alloc_env(UnifexEnv *env) { return env; }
-
 static inline void unifex_clear_env(UnifexEnv *_env) { UNIFEX_UNUSED(_env); }
-
 static inline void unifex_free_env(UnifexEnv *_env) { UNIFEX_UNUSED(_env); }
 
-static inline UnifexPid *unifex_self(UnifexEnv *env, UnifexPid *pid) {
-  return (UnifexPid *) memcpy(pid, env->reply_to, sizeof(UnifexPid));
-};
-
-// Threads
+/** 
+ * Threads
+ * 
+ * To use these functions compile and link with -pthread.
+ * Refer to bundlex project documentation to see how to do it.
+*/
 typedef pthread_t UnifexTid;
 static inline int unifex_thread_create(char *name, UnifexTid *tid, void *(*func)(void *), void *args) {
   UNIFEX_UNUSED(name);
   return pthread_create(tid, NULL, func, args);
 }
-
 static inline void unifex_thread_exit(void *exit_val) {
   pthread_exit(exit_val);
 }
-
 static inline int unifex_thread_join(UnifexTid tid, void **exit_val) {
   return pthread_join(tid, exit_val);
 }
+
+// pid
+static inline UnifexPid *unifex_self(UnifexEnv *env, UnifexPid *pid) {
+  return (UnifexPid *) memcpy(pid, env->reply_to, sizeof(UnifexPid));
+};
 
 UNIFEX_TERM unifex_raise(UnifexEnv *env, const char *message);
 

--- a/c_src/unifex/nif/unifex/payload.h
+++ b/c_src/unifex/nif/unifex/payload.h
@@ -22,15 +22,14 @@ struct _UnifexPayload {
 typedef struct _UnifexPayload UnifexPayload;
 
 extern ErlNifResourceType *UNIFEX_PAYLOAD_GUARD_RESOURCE_TYPE;
-UnifexPayload *unifex_payload_alloc(UnifexEnv *env, UnifexPayloadType type,
-                                    unsigned int size);
+int unifex_payload_alloc(UnifexEnv *env, UnifexPayloadType type,
+                                    unsigned int size, UnifexPayload *payload);
 int unifex_payload_from_term(ErlNifEnv *env, ERL_NIF_TERM binary_term,
                              UnifexPayload *payload);
 UNIFEX_TERM unifex_payload_to_term(UnifexEnv *env, UnifexPayload *payload);
 void unifex_payload_guard_destructor(UnifexEnv *env, void *resource);
 int unifex_payload_realloc(UnifexPayload *payload, unsigned int size);
 void unifex_payload_release(UnifexPayload *payload);
-void unifex_payload_release_ptr(UnifexPayload **payload);
 
 #ifdef __cplusplus
 }

--- a/lib/unifex/code_generator/base_types/payload.ex
+++ b/lib/unifex/code_generator/base_types/payload.ex
@@ -37,7 +37,10 @@ defmodule Unifex.CodeGenerator.BaseTypes.Payload do
 
     @impl BaseType
     def generate_destruction(name, _ctx) do
-      ~g<unifex_payload_release_ptr(&#{name});>
+      ~g"""
+      unifex_payload_release(#{name});
+      unifex_free(#{name});
+      """
     end
   end
 
@@ -67,6 +70,7 @@ defmodule Unifex.CodeGenerator.BaseTypes.Payload do
       if(#{name} && !#{name}->owned) {
         unifex_payload_release(#{name});
       }
+      unifex_free(#{name});
       """
     end
   end

--- a/test/fixtures/cnode_ref_generated/cnode/example.c
+++ b/test/fixtures/cnode_ref_generated/cnode/example.c
@@ -800,6 +800,7 @@ exit_test_payload_caller:
   if (in_payload && !in_payload->owned) {
     unifex_payload_release(in_payload);
   }
+  unifex_free(in_payload);
 
   return result;
 }

--- a/test/fixtures/cnode_ref_generated/cnode/example.cpp
+++ b/test/fixtures/cnode_ref_generated/cnode/example.cpp
@@ -800,6 +800,7 @@ exit_test_payload_caller:
   if (in_payload && !in_payload->owned) {
     unifex_payload_release(in_payload);
   }
+  unifex_free(in_payload);
 
   return result;
 }

--- a/test_projects/cnode/c_src/example/example.c
+++ b/test_projects/cnode/c_src/example/example.c
@@ -50,13 +50,12 @@ UNIFEX_TERM test_list_with_other_args(UnifexEnv *env, int *in_list,
 }
 
 UNIFEX_TERM test_payload(UnifexEnv *env, UnifexPayload *in_payload) {
-  UnifexPayload *out_payload = (UnifexPayload *)unifex_alloc(sizeof(UnifexPayload));
-  unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, in_payload->size, out_payload);
-  memcpy(out_payload->data, in_payload->data, out_payload->size);
-  out_payload->data[0]++;
-  UNIFEX_TERM result = test_payload_result_ok(env, out_payload);
-  unifex_payload_release(out_payload);
-  unifex_free(out_payload);
+  UnifexPayload out_payload;
+  unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, in_payload->size, &out_payload);
+  memcpy(out_payload.data, in_payload->data, out_payload.size);
+  out_payload.data[0]++;
+  UNIFEX_TERM result = test_payload_result_ok(env, &out_payload);
+  unifex_payload_release(&out_payload);
   return result;
 }
 

--- a/test_projects/cnode/c_src/example/example.c
+++ b/test_projects/cnode/c_src/example/example.c
@@ -50,12 +50,13 @@ UNIFEX_TERM test_list_with_other_args(UnifexEnv *env, int *in_list,
 }
 
 UNIFEX_TERM test_payload(UnifexEnv *env, UnifexPayload *in_payload) {
-  UnifexPayload *out_payload =
-      unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, in_payload->size);
+  UnifexPayload *out_payload = (UnifexPayload *)unifex_alloc(sizeof(UnifexPayload));
+  unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, in_payload->size, out_payload);
   memcpy(out_payload->data, in_payload->data, out_payload->size);
   out_payload->data[0]++;
   UNIFEX_TERM result = test_payload_result_ok(env, out_payload);
   unifex_payload_release(out_payload);
+  unifex_free(out_payload);
   return result;
 }
 


### PR DESCRIPTION
* remove `unifex_payload_release_ptr` 
* expect ptr to allocated `UnifexPayload` struct in `unifex_payload_alloc`
* implement thread API for C node

From now user will be forced to allocate and free `UnifexPayload` struct on its own.
Functions `unifex_payload_alloc` and `unifex_payload_release` should only be used to allocate and free data field in `UnifexPayload` struct. 