### PR TITLE
Revert "Release old binary on realloc"

### DIFF
--- a/c_src/unifex/nif/unifex/payload.c
+++ b/c_src/unifex/nif/unifex/payload.c
@@ -81,20 +81,11 @@ int unifex_payload_realloc(UnifexPayload *payload, unsigned int size) {
   int res = 1;
   payload->size = size;
   Shmex *shmex;
-  ErlNifBinary *old_binary;
 
   switch (payload->type) {
   case UNIFEX_PAYLOAD_BINARY:
-    old_binary = &payload->payload_struct.binary;
-    res = enif_realloc_binary(&payload->payload_struct.binary, size);
-    if (!res) {
-      return 0;
-    }
-
-    if (payload->owned) {
-      enif_release_binary(old_binary);
-    }
     payload->owned = 1;
+    res = enif_realloc_binary(&payload->payload_struct.binary, size);
     payload->data = payload->payload_struct.binary.data;
     break;
   case UNIFEX_PAYLOAD_SHM:


### PR DESCRIPTION
Turns out this PR was useless and comes from my overinterpretation of docs - if the binary is owned (i.e. mutable) it has to be released but only once, in the end. Realloc does modify the binary struct in place doing the reallocation of internal data structure, so no need to release it in between