### PR TITLE
Removing uint from the documentation

### DIFF
--- a/pages/supported_types.md
+++ b/pages/supported_types.md
@@ -7,11 +7,10 @@ You can also refer to [#42](https://github.com/membraneframework/unifex/issues/4
 state of work on remaining types.
 
 ## NIF
-| type    | as function parameter | as return type  |
-| ------- | :-------------------: | :-------------: |
+| type      | as function parameter | as return type  |
+| --------- | :-------------------: | :-------------: |
 | `atom`    | yes                   | yes             |
 | `bool`    | yes                   | yes             |
-| `uint`    | yes                   | yes             |
 | `uint64`  | yes                   | yes             |
 | `int`     | yes                   | yes             |
 | `int64`   | yes                   | yes             |
@@ -22,11 +21,10 @@ state of work on remaining types.
 | `string`  | yes                   | yes             |
 
 ## CNode
-| type    | as function parameter | as return type  |
-| ------- | :-------------------: | :-------------: |
+| type      | as function parameter | as return type  |
+| --------- | :-------------------: | :-------------: |
 | `atom`    | yes                   | yes             |
 | `bool`    | yes                   | yes             |
-| `uint`    | yes                   | yes             |
 | `uint64`  | no                    | no              |
 | `int`     | yes                   | yes             |
 | `int64`   | no                    | no              |

--- a/pages/supported_types.md
+++ b/pages/supported_types.md
@@ -11,6 +11,7 @@ state of work on remaining types.
 | --------- | :-------------------: | :-------------: |
 | `atom`    | yes                   | yes             |
 | `bool`    | yes                   | yes             |
+| `unsigned`| yes                   | yes             |
 | `uint64`  | yes                   | yes             |
 | `int`     | yes                   | yes             |
 | `int64`   | yes                   | yes             |
@@ -25,6 +26,7 @@ state of work on remaining types.
 | --------- | :-------------------: | :-------------: |
 | `atom`    | yes                   | yes             |
 | `bool`    | yes                   | yes             |
+| `unsigned`| yes                   | yes             |
 | `uint64`  | no                    | no              |
 | `int`     | yes                   | yes             |
 | `int64`   | no                    | no              |


### PR DESCRIPTION
Having discussed it with Bartek, type uint shouldn't, and isn't, supported by Unifex. It only works by using the `BaseTypes.Default` functions and System V compatibility typedef which is not present on all systems. Namely, it is not defined on Alpine, which is what our CI runs on. Therefore, mentioning it in the documentation is confusing at best.