### PR TITLE
Fix struct parsing when using lists

### DIFF
--- a/lib/unifex/code_generator/base_types/struct.ex
+++ b/lib/unifex/code_generator/base_types/struct.ex
@@ -76,7 +76,11 @@ defmodule Unifex.CodeGenerator.BaseTypes.Struct do
     def generate_arg_parse(arg, var_name, ctx) do
       %{postproc_fun: postproc_fun, generator: generator} = ctx
 
-      unique_sufix = String.replace("#{var_name}", ".", "_")
+      unique_sufix =
+        "#{var_name}"
+        # replace array naming
+        |> String.replace("[i]", "")
+        |> String.replace(".", "_")
 
       fields_parsing =
         ctx.type_spec.fields

--- a/lib/unifex/code_generator/base_types/struct.ex
+++ b/lib/unifex/code_generator/base_types/struct.ex
@@ -76,22 +76,18 @@ defmodule Unifex.CodeGenerator.BaseTypes.Struct do
     def generate_arg_parse(arg, var_name, ctx) do
       %{postproc_fun: postproc_fun, generator: generator} = ctx
 
-      unique_sufix =
-        "#{var_name}"
-        # replace array naming
-        |> String.replace("[i]", "")
-        |> String.replace(".", "_")
+      unique_suffix = Unifex.CodeGenerator.Utils.sanitize_var_name("#{var_name}")
 
       fields_parsing =
         ctx.type_spec.fields
         |> Enum.map_join("\n", fn {field_name, field_type} ->
           ~g"""
-          key_#{unique_sufix} = enif_make_atom(env, "#{field_name}");
-          int get_#{field_name}_result = enif_get_map_value(env, #{arg}, key_#{unique_sufix}, &value_#{unique_sufix});
+          key_#{unique_suffix} = enif_make_atom(env, "#{field_name}");
+          int get_#{field_name}_result = enif_get_map_value(env, #{arg}, key_#{unique_suffix}, &value_#{unique_suffix});
           if (get_#{field_name}_result) {
             #{BaseType.generate_arg_parse(field_type,
           :"#{var_name}.#{field_name}",
-          ~g<value_#{unique_sufix}>,
+          ~g<value_#{unique_suffix}>,
           postproc_fun,
           generator,
           ctx)}
@@ -105,8 +101,8 @@ defmodule Unifex.CodeGenerator.BaseTypes.Struct do
 
       ~g"""
       ({
-        ERL_NIF_TERM key_#{unique_sufix};
-        ERL_NIF_TERM value_#{unique_sufix};
+        ERL_NIF_TERM key_#{unique_suffix};
+        ERL_NIF_TERM value_#{unique_suffix};
 
         #{fields_parsing}
         #{result};

--- a/lib/unifex/code_generator/utils.ex
+++ b/lib/unifex/code_generator/utils.ex
@@ -23,12 +23,9 @@ defmodule Unifex.CodeGenerator.Utils do
   """
   @spec sanitize_var_name(String.t()) :: String.t()
   def sanitize_var_name(var_name) do
-    var_name =
-      var_name
-      |> String.replace(".", "_")
-      |> String.replace("->", "_")
-
-    Regex.replace(~r/\[(.*)\]/, var_name, "_\\1")
+    var_name
+    |> String.replace([".", "->"], "_")
+    |> String.replace(~r/\[(.*)\]/, "_\\1")
   end
 
   @doc """

--- a/lib/unifex/code_generator/utils.ex
+++ b/lib/unifex/code_generator/utils.ex
@@ -16,6 +16,22 @@ defmodule Unifex.CodeGenerator.Utils do
   end
 
   @doc """
+  Replaces special characters such as: `.`, `->` and array brackets e.g. `var_name[i]`
+  with underscores.
+
+  In case of arrays `var_name[i]` results in `var_name_i`.
+  """
+  @spec sanitize_var_name(String.t()) :: String.t()
+  def sanitize_var_name(var_name) do
+    var_name =
+      var_name
+      |> String.replace(".", "_")
+      |> String.replace("->", "_")
+
+    Regex.replace(~r/\[(.*)\]/, var_name, "_\\1")
+  end
+
+  @doc """
   Traverses Elixir specification AST and creates C data types serialization
   with `serializers`.
   """

--- a/test/fixtures/nif_ref_generated/nif/example.c
+++ b/test/fixtures/nif_ref_generated/nif/example.c
@@ -410,10 +410,13 @@ static ERL_NIF_TERM export_test_list(ErlNifEnv *env, int argc,
           for (unsigned int i = 0; i < in_list_length; i++) {
             ERL_NIF_TERM elem;
             enif_get_list_cell(env, list, &elem, &list);
-            if (!enif_get_int(env, elem, &in_list[i])) {
+            int in_list_i = in_list[i];
+            if (!enif_get_int(env, elem, &in_list_i)) {
               result = unifex_raise_args_error(env, "in_list", "{:list, :int}");
               goto exit_export_test_list;
             }
+
+            in_list[i] = in_list_i;
           }
         }
         get_list_length_result;
@@ -459,11 +462,14 @@ static ERL_NIF_TERM export_test_list_of_strings(ErlNifEnv *env, int argc,
           for (unsigned int i = 0; i < in_strings_length; i++) {
             ERL_NIF_TERM elem;
             enif_get_list_cell(env, list, &elem, &list);
-            if (!unifex_string_from_term(env, elem, &in_strings[i])) {
+            char *in_strings_i = in_strings[i];
+            if (!unifex_string_from_term(env, elem, &in_strings_i)) {
               result = unifex_raise_args_error(env, "in_strings",
                                                "{:list, :string}");
               goto exit_export_test_list_of_strings;
             }
+
+            in_strings[i] = in_strings_i;
           }
         }
         get_list_length_result;
@@ -588,11 +594,14 @@ static ERL_NIF_TERM export_test_my_struct(ErlNifEnv *env, int argc,
                   for (unsigned int i = 0; i < in_struct.data_length; i++) {
                     ERL_NIF_TERM elem;
                     enif_get_list_cell(env, list, &elem, &list);
-                    if (!enif_get_int(env, elem, &in_struct.data[i])) {
+                    int in_struct_data_i = in_struct.data[i];
+                    if (!enif_get_int(env, elem, &in_struct_data_i)) {
                       result = unifex_raise_args_error(env, "in_struct",
                                                        ":my_struct");
                       goto exit_export_test_my_struct;
                     }
+
+                    in_struct.data[i] = in_struct_data_i;
                   }
                 }
                 get_list_length_result;
@@ -689,13 +698,17 @@ static ERL_NIF_TERM export_test_nested_struct(ErlNifEnv *env, int argc,
                                i < in_struct.inner_struct.data_length; i++) {
                             ERL_NIF_TERM elem;
                             enif_get_list_cell(env, list, &elem, &list);
-                            if (!enif_get_int(
-                                    env, elem,
-                                    &in_struct.inner_struct.data[i])) {
+                            int in_struct_inner_struct_data_i =
+                                in_struct.inner_struct.data[i];
+                            if (!enif_get_int(env, elem,
+                                              &in_struct_inner_struct_data_i)) {
                               result = unifex_raise_args_error(
                                   env, "in_struct", ":nested_struct");
                               goto exit_export_test_nested_struct;
                             }
+
+                            in_struct.inner_struct.data[i] =
+                                in_struct_inner_struct_data_i;
                           }
                         }
                         get_list_length_result;

--- a/test/fixtures/nif_ref_generated/nif/example.c
+++ b/test/fixtures/nif_ref_generated/nif/example.c
@@ -202,6 +202,44 @@ UNIFEX_TERM test_nested_struct_result_ok(UnifexEnv *env,
   });
 }
 
+UNIFEX_TERM
+test_list_of_structs_result_ok(UnifexEnv *env,
+                               simple_struct const *out_struct_list,
+                               unsigned int out_struct_list_length) {
+  return ({
+    const ERL_NIF_TERM terms[] = {
+        enif_make_atom(env, "ok"), ({
+          ERL_NIF_TERM list = enif_make_list(env, 0);
+          for (int i = out_struct_list_length - 1; i >= 0; i--) {
+            list = enif_make_list_cell(
+                env, ({
+                  ERL_NIF_TERM keys[3];
+                  ERL_NIF_TERM values[3];
+
+                  keys[0] = enif_make_atom(env, "id");
+                  values[0] = enif_make_int(env, out_struct_list[i].id);
+
+                  keys[1] = enif_make_atom(env, "name");
+                  values[1] =
+                      unifex_string_to_term(env, out_struct_list[i].name);
+
+                  keys[2] = enif_make_atom(env, "__struct__");
+                  values[2] = enif_make_atom(env, "Elixir.SimpleStruct");
+
+                  ERL_NIF_TERM result;
+                  enif_make_map_from_arrays(env, keys, values, 3, &result);
+                  result;
+                }),
+                list);
+          }
+          list;
+        })
+
+    };
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
 UNIFEX_TERM test_my_enum_result_ok(UnifexEnv *env, MyEnum out_enum) {
   return ({
     const ERL_NIF_TERM terms[] = {
@@ -771,6 +809,91 @@ exit_export_test_nested_struct:
   return result;
 }
 
+static ERL_NIF_TERM export_test_list_of_structs(ErlNifEnv *env, int argc,
+                                                const ERL_NIF_TERM argv[]) {
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
+  ERL_NIF_TERM result;
+  UnifexEnv *unifex_env = env;
+  simple_struct *struct_list;
+  unsigned int struct_list_length;
+
+  struct_list = NULL;
+
+  if (!({
+        int get_list_length_result =
+            enif_get_list_length(env, argv[0], &struct_list_length);
+        if (get_list_length_result) {
+          struct_list = (simple_struct *)enif_alloc(sizeof(simple_struct) *
+                                                    struct_list_length);
+
+          for (unsigned int i = 0; i < struct_list_length; i++) {
+            struct_list[i].name = NULL;
+          }
+
+          ERL_NIF_TERM list = argv[0];
+          for (unsigned int i = 0; i < struct_list_length; i++) {
+            ERL_NIF_TERM elem;
+            enif_get_list_cell(env, list, &elem, &list);
+            simple_struct struct_list_i = struct_list[i];
+            if (!({
+                  ERL_NIF_TERM key_struct_list_i;
+                  ERL_NIF_TERM value_struct_list_i;
+
+                  key_struct_list_i = enif_make_atom(env, "id");
+                  int get_id_result = enif_get_map_value(
+                      env, elem, key_struct_list_i, &value_struct_list_i);
+                  if (get_id_result) {
+                    if (!enif_get_int(env, value_struct_list_i,
+                                      &struct_list_i.id)) {
+                      result = unifex_raise_args_error(
+                          env, "struct_list", "{:list, :simple_struct}");
+                      goto exit_export_test_list_of_structs;
+                    }
+                  }
+
+                  key_struct_list_i = enif_make_atom(env, "name");
+                  int get_name_result = enif_get_map_value(
+                      env, elem, key_struct_list_i, &value_struct_list_i);
+                  if (get_name_result) {
+                    if (!unifex_string_from_term(env, value_struct_list_i,
+                                                 &struct_list_i.name)) {
+                      result = unifex_raise_args_error(
+                          env, "struct_list", "{:list, :simple_struct}");
+                      goto exit_export_test_list_of_structs;
+                    }
+                  }
+
+                  get_id_result &&get_name_result;
+                })) {
+              result = unifex_raise_args_error(env, "struct_list",
+                                               "{:list, :simple_struct}");
+              goto exit_export_test_list_of_structs;
+            }
+
+            struct_list[i] = struct_list_i;
+          }
+        }
+        get_list_length_result;
+      })) {
+    result =
+        unifex_raise_args_error(env, "struct_list", "{:list, :simple_struct}");
+    goto exit_export_test_list_of_structs;
+  }
+
+  result = test_list_of_structs(unifex_env, struct_list, struct_list_length);
+  goto exit_export_test_list_of_structs;
+exit_export_test_list_of_structs:
+  if (struct_list != NULL) {
+    for (unsigned int i = 0; i < struct_list_length; i++) {
+      unifex_free(struct_list[i].name);
+    }
+    unifex_free(struct_list);
+  }
+
+  return result;
+}
+
 static ERL_NIF_TERM export_test_my_enum(ErlNifEnv *env, int argc,
                                         const ERL_NIF_TERM argv[]) {
   UNIFEX_MAYBE_UNUSED(argc);
@@ -832,6 +955,7 @@ static ErlNifFunc nif_funcs[] = {
     {"unifex_test_example_message", 1, export_test_example_message, 0},
     {"unifex_test_my_struct", 1, export_test_my_struct, 0},
     {"unifex_test_nested_struct", 1, export_test_nested_struct, 0},
+    {"unifex_test_list_of_structs", 1, export_test_list_of_structs, 0},
     {"unifex_test_my_enum", 1, export_test_my_enum, 0}};
 
 ERL_NIF_INIT(Elixir.Example.Nif, nif_funcs, unifex_load_nif, NULL, NULL, NULL)

--- a/test/fixtures/nif_ref_generated/nif/example.cpp
+++ b/test/fixtures/nif_ref_generated/nif/example.cpp
@@ -410,10 +410,13 @@ static ERL_NIF_TERM export_test_list(ErlNifEnv *env, int argc,
           for (unsigned int i = 0; i < in_list_length; i++) {
             ERL_NIF_TERM elem;
             enif_get_list_cell(env, list, &elem, &list);
-            if (!enif_get_int(env, elem, &in_list[i])) {
+            int in_list_i = in_list[i];
+            if (!enif_get_int(env, elem, &in_list_i)) {
               result = unifex_raise_args_error(env, "in_list", "{:list, :int}");
               goto exit_export_test_list;
             }
+
+            in_list[i] = in_list_i;
           }
         }
         get_list_length_result;
@@ -459,11 +462,14 @@ static ERL_NIF_TERM export_test_list_of_strings(ErlNifEnv *env, int argc,
           for (unsigned int i = 0; i < in_strings_length; i++) {
             ERL_NIF_TERM elem;
             enif_get_list_cell(env, list, &elem, &list);
-            if (!unifex_string_from_term(env, elem, &in_strings[i])) {
+            char *in_strings_i = in_strings[i];
+            if (!unifex_string_from_term(env, elem, &in_strings_i)) {
               result = unifex_raise_args_error(env, "in_strings",
                                                "{:list, :string}");
               goto exit_export_test_list_of_strings;
             }
+
+            in_strings[i] = in_strings_i;
           }
         }
         get_list_length_result;
@@ -588,11 +594,14 @@ static ERL_NIF_TERM export_test_my_struct(ErlNifEnv *env, int argc,
                   for (unsigned int i = 0; i < in_struct.data_length; i++) {
                     ERL_NIF_TERM elem;
                     enif_get_list_cell(env, list, &elem, &list);
-                    if (!enif_get_int(env, elem, &in_struct.data[i])) {
+                    int in_struct_data_i = in_struct.data[i];
+                    if (!enif_get_int(env, elem, &in_struct_data_i)) {
                       result = unifex_raise_args_error(env, "in_struct",
                                                        ":my_struct");
                       goto exit_export_test_my_struct;
                     }
+
+                    in_struct.data[i] = in_struct_data_i;
                   }
                 }
                 get_list_length_result;
@@ -689,13 +698,17 @@ static ERL_NIF_TERM export_test_nested_struct(ErlNifEnv *env, int argc,
                                i < in_struct.inner_struct.data_length; i++) {
                             ERL_NIF_TERM elem;
                             enif_get_list_cell(env, list, &elem, &list);
-                            if (!enif_get_int(
-                                    env, elem,
-                                    &in_struct.inner_struct.data[i])) {
+                            int in_struct_inner_struct_data_i =
+                                in_struct.inner_struct.data[i];
+                            if (!enif_get_int(env, elem,
+                                              &in_struct_inner_struct_data_i)) {
                               result = unifex_raise_args_error(
                                   env, "in_struct", ":nested_struct");
                               goto exit_export_test_nested_struct;
                             }
+
+                            in_struct.inner_struct.data[i] =
+                                in_struct_inner_struct_data_i;
                           }
                         }
                         get_list_length_result;

--- a/test/fixtures/nif_ref_generated/nif/example.cpp
+++ b/test/fixtures/nif_ref_generated/nif/example.cpp
@@ -202,6 +202,44 @@ UNIFEX_TERM test_nested_struct_result_ok(UnifexEnv *env,
   });
 }
 
+UNIFEX_TERM
+test_list_of_structs_result_ok(UnifexEnv *env,
+                               simple_struct const *out_struct_list,
+                               unsigned int out_struct_list_length) {
+  return ({
+    const ERL_NIF_TERM terms[] = {
+        enif_make_atom(env, "ok"), ({
+          ERL_NIF_TERM list = enif_make_list(env, 0);
+          for (int i = out_struct_list_length - 1; i >= 0; i--) {
+            list = enif_make_list_cell(
+                env, ({
+                  ERL_NIF_TERM keys[3];
+                  ERL_NIF_TERM values[3];
+
+                  keys[0] = enif_make_atom(env, "id");
+                  values[0] = enif_make_int(env, out_struct_list[i].id);
+
+                  keys[1] = enif_make_atom(env, "name");
+                  values[1] =
+                      unifex_string_to_term(env, out_struct_list[i].name);
+
+                  keys[2] = enif_make_atom(env, "__struct__");
+                  values[2] = enif_make_atom(env, "Elixir.SimpleStruct");
+
+                  ERL_NIF_TERM result;
+                  enif_make_map_from_arrays(env, keys, values, 3, &result);
+                  result;
+                }),
+                list);
+          }
+          list;
+        })
+
+    };
+    enif_make_tuple_from_array(env, terms, 2);
+  });
+}
+
 UNIFEX_TERM test_my_enum_result_ok(UnifexEnv *env, MyEnum out_enum) {
   return ({
     const ERL_NIF_TERM terms[] = {
@@ -771,6 +809,91 @@ exit_export_test_nested_struct:
   return result;
 }
 
+static ERL_NIF_TERM export_test_list_of_structs(ErlNifEnv *env, int argc,
+                                                const ERL_NIF_TERM argv[]) {
+  UNIFEX_MAYBE_UNUSED(argc);
+  UNIFEX_MAYBE_UNUSED(argv);
+  ERL_NIF_TERM result;
+  UnifexEnv *unifex_env = env;
+  simple_struct *struct_list;
+  unsigned int struct_list_length;
+
+  struct_list = NULL;
+
+  if (!({
+        int get_list_length_result =
+            enif_get_list_length(env, argv[0], &struct_list_length);
+        if (get_list_length_result) {
+          struct_list = (simple_struct *)enif_alloc(sizeof(simple_struct) *
+                                                    struct_list_length);
+
+          for (unsigned int i = 0; i < struct_list_length; i++) {
+            struct_list[i].name = NULL;
+          }
+
+          ERL_NIF_TERM list = argv[0];
+          for (unsigned int i = 0; i < struct_list_length; i++) {
+            ERL_NIF_TERM elem;
+            enif_get_list_cell(env, list, &elem, &list);
+            simple_struct struct_list_i = struct_list[i];
+            if (!({
+                  ERL_NIF_TERM key_struct_list_i;
+                  ERL_NIF_TERM value_struct_list_i;
+
+                  key_struct_list_i = enif_make_atom(env, "id");
+                  int get_id_result = enif_get_map_value(
+                      env, elem, key_struct_list_i, &value_struct_list_i);
+                  if (get_id_result) {
+                    if (!enif_get_int(env, value_struct_list_i,
+                                      &struct_list_i.id)) {
+                      result = unifex_raise_args_error(
+                          env, "struct_list", "{:list, :simple_struct}");
+                      goto exit_export_test_list_of_structs;
+                    }
+                  }
+
+                  key_struct_list_i = enif_make_atom(env, "name");
+                  int get_name_result = enif_get_map_value(
+                      env, elem, key_struct_list_i, &value_struct_list_i);
+                  if (get_name_result) {
+                    if (!unifex_string_from_term(env, value_struct_list_i,
+                                                 &struct_list_i.name)) {
+                      result = unifex_raise_args_error(
+                          env, "struct_list", "{:list, :simple_struct}");
+                      goto exit_export_test_list_of_structs;
+                    }
+                  }
+
+                  get_id_result &&get_name_result;
+                })) {
+              result = unifex_raise_args_error(env, "struct_list",
+                                               "{:list, :simple_struct}");
+              goto exit_export_test_list_of_structs;
+            }
+
+            struct_list[i] = struct_list_i;
+          }
+        }
+        get_list_length_result;
+      })) {
+    result =
+        unifex_raise_args_error(env, "struct_list", "{:list, :simple_struct}");
+    goto exit_export_test_list_of_structs;
+  }
+
+  result = test_list_of_structs(unifex_env, struct_list, struct_list_length);
+  goto exit_export_test_list_of_structs;
+exit_export_test_list_of_structs:
+  if (struct_list != NULL) {
+    for (unsigned int i = 0; i < struct_list_length; i++) {
+      unifex_free(struct_list[i].name);
+    }
+    unifex_free(struct_list);
+  }
+
+  return result;
+}
+
 static ERL_NIF_TERM export_test_my_enum(ErlNifEnv *env, int argc,
                                         const ERL_NIF_TERM argv[]) {
   UNIFEX_MAYBE_UNUSED(argc);
@@ -832,6 +955,7 @@ static ErlNifFunc nif_funcs[] = {
     {"unifex_test_example_message", 1, export_test_example_message, 0},
     {"unifex_test_my_struct", 1, export_test_my_struct, 0},
     {"unifex_test_nested_struct", 1, export_test_nested_struct, 0},
+    {"unifex_test_list_of_structs", 1, export_test_list_of_structs, 0},
     {"unifex_test_my_enum", 1, export_test_my_enum, 0}};
 
 ERL_NIF_INIT(Elixir.Example.Nif, nif_funcs, unifex_load_nif, NULL, NULL, NULL)

--- a/test/fixtures/nif_ref_generated/nif/example.h
+++ b/test/fixtures/nif_ref_generated/nif/example.h
@@ -82,6 +82,19 @@ typedef struct my_struct_t my_struct;
 #endif
 
 #ifdef __cplusplus
+struct simple_struct {
+  int id;
+  char *name;
+};
+#else
+struct simple_struct_t {
+  int id;
+  char *name;
+};
+typedef struct simple_struct_t simple_struct;
+#endif
+
+#ifdef __cplusplus
 struct nested_struct {
   my_struct inner_struct;
   int id;
@@ -113,6 +126,8 @@ UNIFEX_TERM test_state(UnifexEnv *env, UnifexState *state);
 UNIFEX_TERM test_example_message(UnifexEnv *env, UnifexPid pid);
 UNIFEX_TERM test_my_struct(UnifexEnv *env, my_struct in_struct);
 UNIFEX_TERM test_nested_struct(UnifexEnv *env, nested_struct in_struct);
+UNIFEX_TERM test_list_of_structs(UnifexEnv *env, simple_struct *struct_list,
+                                 unsigned int struct_list_length);
 UNIFEX_TERM test_my_enum(UnifexEnv *env, MyEnum in_enum);
 
 /*
@@ -145,6 +160,9 @@ UNIFEX_TERM test_example_message_result_error(UnifexEnv *env,
 UNIFEX_TERM test_my_struct_result_ok(UnifexEnv *env, my_struct out_struct);
 UNIFEX_TERM test_nested_struct_result_ok(UnifexEnv *env,
                                          nested_struct out_struct);
+UNIFEX_TERM test_list_of_structs_result_ok(UnifexEnv *env,
+                                           simple_struct const *out_struct_list,
+                                           unsigned int out_struct_list_length);
 UNIFEX_TERM test_my_enum_result_ok(UnifexEnv *env, MyEnum out_enum);
 
 /*

--- a/test_projects/nif/c_src/example/example.c
+++ b/test_projects/nif/c_src/example/example.c
@@ -70,6 +70,10 @@ UNIFEX_TERM test_nested_struct(UnifexEnv *env, nested_struct in_struct) {
   return test_nested_struct_result_ok(env, in_struct);
 }
 
+UNIFEX_TERM test_list_of_structs(UnifexEnv *env, simple_struct* structs, unsigned int structs_length) {
+  return test_list_of_structs_result_ok(env, structs, structs_length);
+}
+
 void handle_destroy_state(UnifexEnv *env, MyState *state) {
   UNIFEX_UNUSED(env);
   state->a = 0;

--- a/test_projects/nif/c_src/example/example.spec.exs
+++ b/test_projects/nif/c_src/example/example.spec.exs
@@ -34,6 +34,11 @@ type my_struct :: %My.Struct{
   name: string
 }
 
+type simple_struct :: %SimpleStruct{
+  id: int,
+  name: string
+}
+
 spec test_my_struct(in_struct :: my_struct) :: {:ok :: label, out_struct :: my_struct}
 
 type nested_struct :: %Nested.Struct{
@@ -42,6 +47,8 @@ type nested_struct :: %Nested.Struct{
 }
 
 spec test_nested_struct(in_struct :: nested_struct) :: {:ok :: label, out_struct :: nested_struct}
+
+spec test_list_of_structs(struct_list :: [simple_struct]) :: {:ok :: label, out_struct_list :: [simple_struct]}
 
 type my_enum :: :option_one | :option_two | :option_three | :option_four | :option_five
 


### PR DESCRIPTION
There was a problem when parsing structs that came from a list. 

The code generation assumed that element name was a valid singular which is being used as a temporal variable name.
Having an element name broke the parsing phase as we were operating with arrays instead of single values.