### PR TITLE
Format generated code only when clang-format is available

### DIFF
--- a/lib/unifex/interface_IO.ex
+++ b/lib/unifex/interface_IO.ex
@@ -54,10 +54,13 @@ defmodule Unifex.InterfaceIO do
     File.write!("#{out_base_path}.c", source)
     File.write!("#{out_base_path}.cpp", source)
 
-    Mix.shell().cmd(
-      "clang-format -style=\"{BasedOnStyle: llvm, IndentWidth: 2}\" -i " <>
-        "#{out_base_path}.h #{out_base_path}.c #{out_base_path}.cpp"
-    )
+    # Format generated code only when clang-format is available
+    if Mix.shell().cmd("whereis clang-format") == 0 do
+      Mix.shell().cmd(
+        "clang-format -style=\"{BasedOnStyle: llvm, IndentWidth: 2}\" -i " <>
+          "#{out_base_path}.h #{out_base_path}.c #{out_base_path}.cpp"
+      )
+    end
 
     :ok
   end

--- a/lib/unifex/interface_IO.ex
+++ b/lib/unifex/interface_IO.ex
@@ -55,10 +55,16 @@ defmodule Unifex.InterfaceIO do
     File.write!("#{out_base_path}.cpp", source)
 
     # Format generated code only when clang-format is available
-    if Mix.shell().cmd("whereis clang-format") == 0 do
-      Mix.shell().cmd(
-        "clang-format -style=\"{BasedOnStyle: llvm, IndentWidth: 2}\" -i " <>
-          "#{out_base_path}.h #{out_base_path}.c #{out_base_path}.cpp"
+    if Unifex.Utils.clang_format_installed?() do
+      System.cmd(
+        "clang-format",
+        [
+          "-style={BasedOnStyle: llvm, IndentWidth: 2}",
+          "-i",
+          "#{out_base_path}.h",
+          "#{out_base_path}.c",
+          "#{out_base_path}.cpp"
+        ]
       )
     end
 

--- a/lib/unifex/utils.ex
+++ b/lib/unifex/utils.ex
@@ -2,7 +2,5 @@ defmodule Unifex.Utils do
   @moduledoc false
 
   @spec clang_format_installed?() :: boolean()
-  def clang_format_installed?() do
-    if System.find_executable("clang-format"), do: true, else: false
-  end
+  def clang_format_installed?(), do: System.find_executable("clang-format") != nil
 end

--- a/lib/unifex/utils.ex
+++ b/lib/unifex/utils.ex
@@ -1,0 +1,8 @@
+defmodule Unifex.Utils do
+  @moduledoc false
+
+  @spec clang_format_installed?() :: boolean()
+  def clang_format_installed?() do
+    if System.find_executable("clang-format"), do: true, else: false
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Unifex.MixProject do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.0.2"
   @github_url "https://github.com/membraneframework/unifex"
 
   def project do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,6 @@
-ExUnit.start()
+# clang-format is required to format the generated code
+# it won't match the reference files otherwise
+case System.cmd("clang-format", ~w(--version)) do
+  {_result, 0} -> ExUnit.start()
+  {_result, 1} -> raise "clang-format not found"
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,7 @@
 # clang-format is required to format the generated code
 # it won't match the reference files otherwise
-case System.cmd("clang-format", ~w(--version)) do
-  {_result, 0} -> ExUnit.start()
-  {_result, 1} -> raise "clang-format not found"
+if Unifex.Utils.clang_format_installed?() do
+  ExUnit.start()
+else
+  raise "clang-format has to be installed on the system to run Unifex tests."
 end

--- a/test/unifex/integration_test.exs
+++ b/test/unifex/integration_test.exs
@@ -44,10 +44,6 @@ defmodule Unifex.IntegrationTest do
   defp do_test_project(project, interface, language) do
     run_projects_tests(project, language)
 
-    # clang-format is required to format the generated code
-    # it won't match the reference files otherwise
-    assert {_output, 0} = System.cmd("clang-format", ~w(--version))
-
     test_common(project)
     test_particular(project, interface)
   end


### PR DESCRIPTION
We shouldn't require clang-format to be available on the system. Otherwise, everyone who compiles membrane package and doesn't have clang-format, will get a warning `/usr/bin/sh: 1: clang-format: not found`.

`clang-format` is required in tests so they should remain deterministic.